### PR TITLE
Bootstrap pnpm workspace, Prettier, and CI

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,3 +12,8 @@ trim_trailing_whitespace = true
 
 [*.md]
 max_line_length = off
+trim_trailing_whitespace = false
+
+[{pnpm-*.yaml,package.json}]
+indent_size = 2
+tab_width = 2

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,9 @@
 *                   text=auto
 
 *.md                text eol=lf
+*.yml               text eol=lf
+*.xml               text eol=lf
+*.yaml              text eol=lf
 *.json              text eol=lf
 
 .gitignore          text eol=lf
@@ -12,3 +15,7 @@
 .prettierrc         text eol=lf
 
 LICENSE             text eol=lf
+
+pnpm-lock.yaml      text eol=lf linguist-generated
+
+.run/*.xml          text eol=lf linguist-generated

--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -1,0 +1,9 @@
+name: CI Checks
+description: Runs CI checks for the platform.
+
+runs:
+    using: composite
+    steps:
+        - name: Check formatting
+          shell: bash
+          run: pnpm format-check

--- a/.github/actions/setup-workspace/action.yml
+++ b/.github/actions/setup-workspace/action.yml
@@ -1,0 +1,26 @@
+name: Setup Workspace
+description: Checks out the repository, sets up Node.js and pnpm, and optionally installs dependencies.
+
+inputs:
+    install-dependencies:
+        description: Whether to install workspace dependencies.
+        default: 'true'
+
+runs:
+    using: composite
+    steps:
+        - name: Setup pnpm
+          uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+          with:
+              version: 10.34.1
+
+        - name: Setup Node.js
+          uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+          with:
+              node-version-file: package.json
+              cache: ${{ inputs.install-dependencies == 'true' && 'pnpm' || '' }}
+
+        - name: Install dependencies
+          if: inputs.install-dependencies == 'true'
+          shell: bash
+          run: pnpm install

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,24 @@
+name: Pull Request
+
+on:
+    pull_request:
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    ci:
+        name: CI
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+        steps:
+            - name: Checkout
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+            - name: Setup workspace
+              uses: ./.github/actions/setup-workspace
+
+            - name: Run CI checks
+              uses: ./.github/actions/ci

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -1,0 +1,25 @@
+name: Push to Main
+
+on:
+    push:
+        branches:
+            - main
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+    ci:
+        name: CI
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+        steps:
+            - name: Checkout
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+            - name: Setup workspace
+              uses: ./.github/actions/setup-workspace
+
+            - name: Run CI checks
+              uses: ./.github/actions/ci

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 .idea/
+.vscode/*
+!.vscode/extensions.json
+!.vscode/settings.json
+
+node_modules/

--- a/.prettierignore
+++ b/.prettierignore
@@ -19,3 +19,12 @@
 !*.ts
 
 !.prettierrc
+
+node_modules/
+pnpm-lock.yaml
+
+.run/
+.idea/
+.vscode/*
+!.vscode/extensions.json
+!.vscode/settings.json

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,13 @@
 {
-    "overrides": [],
-    "plugins": [],
+    "overrides": [
+        {
+            "files": ["pnpm-*.yaml", "package.json"],
+            "options": {
+                "tabWidth": 2
+            }
+        }
+    ],
+    "plugins": ["prettier-plugin-organize-imports"],
     "printWidth": 120,
     "quoteProps": "consistent",
     "singleQuote": true,

--- a/.run/format-check.run.xml
+++ b/.run/format-check.run.xml
@@ -1,0 +1,13 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="format-check" type="js.build_tools.npm" folderName="formatting">
+    <package-json value="$PROJECT_DIR$/package.json" />
+    <command value="run" />
+    <scripts>
+      <script value="format-check" />
+    </scripts>
+    <node-interpreter value="project" />
+    <envs />
+    <EXTENSION ID="com.github.l34130.mise.core.run.MiseRunConfigurationSettingsEditor" myConfigEnvironmentStrategy="use_project_settings" myMiseDirEnvCb="false" myMiseConfigEnvironmentTf="" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/format.run.xml
+++ b/.run/format.run.xml
@@ -1,0 +1,13 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="format" type="js.build_tools.npm" folderName="formatting" nameIsGenerated="true">
+    <package-json value="$PROJECT_DIR$/package.json" />
+    <command value="run" />
+    <scripts>
+      <script value="format" />
+    </scripts>
+    <node-interpreter value="project" />
+    <envs />
+    <EXTENSION ID="com.github.l34130.mise.core.run.MiseRunConfigurationSettingsEditor" myConfigEnvironmentStrategy="use_project_settings" myMiseDirEnvCb="false" myMiseConfigEnvironmentTf="" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+    "recommendations": ["esbenp.prettier-vscode"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Agent configuration
+
+## Issue tracker
+
+This repo uses GitHub Issues and GitHub Project #7 ("D&D Mapp") for issue tracking. For configuration, see [docs/agents/issue-tracker.md](docs/agents/issue-tracker.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# Claude instructions
+
+For agent instructions and repo-specific configuration, see [AGENTS.md](AGENTS.md).

--- a/README.md
+++ b/README.md
@@ -1,3 +1,48 @@
 # dma-platform
 
-Monorepo for the D&amp;D Mapp platform — libraries and applications powering character management, campaign tools, and Virtual Tabletop sessions for D&amp;D 5e.
+[![Main](https://github.com/dnd-mapp/dma-platform/actions/workflows/push-main.yml/badge.svg)](https://github.com/dnd-mapp/dma-platform/actions/workflows/push-main.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![node: 24.16.0](https://img.shields.io/badge/node-24.16.0-339933?logo=nodedotjs&logoColor=white)](package.json)
+[![pnpm: 10.34.1](https://img.shields.io/badge/pnpm-10.34.1-F69220?logo=pnpm&logoColor=white)](package.json)
+
+Monorepo for the D&D Mapp platform — libraries and applications powering character management, campaign tools, and Virtual Tabletop sessions for D&D 5e.
+
+## Prerequisites
+
+- **[mise](https://mise.jdx.dev/getting-started.html)** — manages the Node.js and pnpm versions declared in `package.json`
+
+## Getting started
+
+1. Install mise by following the [official getting started guide](https://mise.jdx.dev/getting-started.html).
+
+2. Activate the required toolchain versions:
+
+    ```sh
+    mise install
+    ```
+
+3. Install workspace dependencies:
+
+    ```sh
+    pnpm install
+    ```
+
+## Editor setup
+
+### VS Code
+
+1. Install the [Prettier - Code formatter](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) extension.
+2. Add the following to your workspace or user settings:
+
+    ```json
+    {
+        "editor.defaultFormatter": "esbenp.prettier-vscode",
+        "editor.formatOnSave": true
+    }
+    ```
+
+### WebStorm
+
+1. Open **Settings** → **Languages & Frameworks** → **Prettier**.
+2. Set **Prettier package** to the project's local installation (`node_modules/prettier`).
+3. Enable **Run on save**.

--- a/docs/adr/0001-mise-for-toolchain-version-management.md
+++ b/docs/adr/0001-mise-for-toolchain-version-management.md
@@ -1,0 +1,24 @@
+# ADR 0001: Use mise for runtime and toolchain version management
+
+- **Status:** Accepted
+- **Date:** 2026-05-29
+
+## Context
+
+The monorepo requires a consistent Node.js and pnpm version across all contributors and CI environments. Several tools can enforce or manage this:
+
+- **Corepack** (built into Node) — pins the package manager via the `packageManager` field in `package.json`; can auto-install the pinned version
+- **Volta** — pins both Node and package manager versions in `package.json`; silently installs and switches versions per-project
+- **mise** — a polyglot version manager (successor to asdf) that manages Node, pnpm, and any other tool; supports idiomatic version files including `package.json` (via `engines` / `devEngines`), so no separate mise config file is required
+- **nvm / fnm** — Node-only version managers that read `.nvmrc`; require manual activation
+
+## Decision
+
+Use **mise** to manage Node and pnpm versions. pnpm is configured with `managePackageManagerVersions: false` so it only validates the version in use rather than installing or switching it. Required versions are declared in `package.json` via the `engines` and `devEngines` fields so that pnpm reports a clear error when the wrong versions are active.
+
+## Consequences
+
+- Contributors and CI must have mise installed and configured to activate the correct versions.
+- pnpm will error (`engineStrict: true`) if the active Node version does not match, giving a clear signal to check mise.
+- The `packageManager` field (Corepack) is intentionally omitted to avoid two competing tools fighting over pnpm version management.
+- Version updates only require a change to `package.json`; mise reads the `engines` / `devEngines` fields directly via its idiomatic version file support.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,28 @@
+# Issue Tracker
+
+## Tracker Backend
+
+github-issues-projects
+
+## GitHub
+
+- **Repo:** `dnd-mapp/dma-platform`
+- **Org:** `dnd-mapp`
+- **Project:** `#7` — "D&D Mapp" (`PVT_kwDODFcis84BY-C4`)
+
+## Issue Types
+
+Configured as GitHub org-level issue types. For full definitions, see [issue-types.md](issue-types.md).
+
+## Field representation
+
+Fields are stored in two places:
+
+- **Org-level issue fields** — set on the GitHub Issue itself (Priority, Severity, Story Points, Time Box)
+- **Project fields** — set on the Project item (Status, Target Quarter, Parent issue)
+
+## Linking conventions
+
+- `Parent #<n>` — parent reference
+- `Closes #<n>` — resolution reference
+- `Refs #<n>` — related reference

--- a/docs/agents/issue-types.md
+++ b/docs/agents/issue-types.md
@@ -1,0 +1,216 @@
+# Issue Types
+
+## Epic
+
+**Hierarchy:** can contain Stories and Spikes
+
+### Issue Type
+
+Org-level issue type: `Epic` (node ID: `IT_kwDODFcis84CBKdR`)
+
+### Fields
+
+| Field       | Kind                  | Node ID                         | Type          | Values / format               |
+|:------------|:----------------------|:--------------------------------|:--------------|:------------------------------|
+| `priority`  | Org-level issue field | `IFSS_kgDOAopeGg`               | Single-select | P0 \| P1 \| P2 \| P3          |
+| `iteration` | Project field         | `PVTIF_lADODFcis84BY-C4zhUBQBo` | Iteration     | Q2 2026 \| Q3 2026 \| Q4 2026 |
+
+**Priority options** (org-level issue field `IFSS_kgDOAopeGg`):
+
+| Value | ID         | Description                                                 |
+|:------|:-----------|:------------------------------------------------------------|
+| `P0`  | `74587961` | Drop everything — blocking critical path or a live incident |
+| `P1`  | `74587962` | High priority — must be addressed this quarter              |
+| `P2`  | `74587963` | Normal priority — planned and scheduled                     |
+| `P3`  | `74587964` | Low priority — nice to have, no firm commitment             |
+
+### Statuses
+
+`Status` Project field (single-select, node ID: `PVTSSF_lADODFcis84BY-C4zhUADuc`):
+
+| Status        | Option ID  |
+|:--------------|:-----------|
+| `backlog`     | `f75ad846` |
+| `in-progress` | `0d8b05a3` |
+| `done`        | `8f8e8157` |
+
+### Body template
+
+```md
+## Goal
+
+## Scope
+
+## Out of scope
+```
+
+---
+
+## Story
+
+**Hierarchy:** child of Epic
+
+### Issue Type
+
+Org-level issue type: `Story` (node ID: `IT_kwDODFcis84CBKrx`)
+
+### Fields
+
+| Field        | Kind                   | Node ID                        | Type          | Values / format             |
+|:-------------|:-----------------------|:-------------------------------|:--------------|:----------------------------|
+| `priority`   | Org-level issue field  | `IFSS_kgDOAopeGg`              | Single-select | P0 \| P1 \| P2 \| P3        |
+| `estimation` | Org-level issue field  | `IFN_kgDOAoptyA`               | Number        | 1 \| 2 \| 3 \| 5 \| 8 \| 13 |
+| `parent`     | Project field (native) | `PVTF_lADODFcis84BY-C4zhUADu4` | Parent issue  | `Parent #<n>`               |
+
+**Priority options:** see Epic section above.
+
+### Statuses
+
+`Status` Project field (single-select, node ID: `PVTSSF_lADODFcis84BY-C4zhUADuc`):
+
+| Status        | Option ID  |
+|:--------------|:-----------|
+| `backlog`     | `f75ad846` |
+| `ready`       | `6479c4dc` |
+| `in-progress` | `0d8b05a3` |
+| `in-review`   | `441688e8` |
+| `done`        | `8f8e8157` |
+
+### Body template
+
+```md
+## User Story
+
+As a [persona], I want [goal], so that [reason].
+
+## Acceptance criteria
+
+- [ ]
+- [ ]
+```
+
+---
+
+## Task
+
+**Hierarchy:** child of Story
+
+### Issue Type
+
+Org-level issue type: `Task` (node ID: `IT_kwDODFcis84CBKxI`)
+
+### Fields
+
+| Field    | Kind                   | Node ID                        | Type         | Values / format |
+|:---------|:-----------------------|:-------------------------------|:-------------|:----------------|
+| `parent` | Project field (native) | `PVTF_lADODFcis84BY-C4zhUADu4` | Parent issue | `Parent #<n>`   |
+
+### Statuses
+
+`Status` Project field (single-select, node ID: `PVTSSF_lADODFcis84BY-C4zhUADuc`):
+
+| Status        | Option ID  |
+|:--------------|:-----------|
+| `backlog`     | `f75ad846` |
+| `in-progress` | `0d8b05a3` |
+| `in-review`   | `441688e8` |
+| `done`        | `8f8e8157` |
+
+### Body template
+
+```md
+## Description
+```
+
+---
+
+## Bug
+
+**Hierarchy:** standalone
+
+### Issue Type
+
+Org-level issue type: `Bug` (node ID: `IT_kwDODFcis84CBK3a`)
+
+### Fields
+
+| Field      | Kind                  | Node ID           | Type          | Values / format      |
+|:-----------|:----------------------|:------------------|:--------------|:---------------------|
+| `priority` | Org-level issue field | `IFSS_kgDOAopeGg` | Single-select | P0 \| P1 \| P2 \| P3 |
+| `severity` | Org-level issue field | `IFSS_kgDOAoplog` | Single-select | S0 \| S1 \| S2 \| S3 |
+
+**Priority options:** see Epic section above.
+
+**Severity options** (org-level issue field `IFSS_kgDOAoplog`):
+
+| Value | ID         | Description                                                           |
+|:------|:-----------|:----------------------------------------------------------------------|
+| `S0`  | `74591344` | Data loss, corruption, or complete feature failure with no workaround |
+| `S1`  | `74591345` | Core flow broken; workaround exists but is painful                    |
+| `S2`  | `74591346` | Degraded experience; reasonable workaround available                  |
+| `S3`  | `74591347` | Cosmetic or minor issue; does not impact functionality                |
+
+### Statuses
+
+`Status` Project field (single-select, node ID: `PVTSSF_lADODFcis84BY-C4zhUADuc`):
+
+| Status        | Option ID  |
+|:--------------|:-----------|
+| `backlog`     | `f75ad846` |
+| `ready`       | `6479c4dc` |
+| `in-progress` | `0d8b05a3` |
+| `in-review`   | `441688e8` |
+| `done`        | `8f8e8157` |
+
+### Body template
+
+```md
+## Steps to reproduce
+
+## Expected
+
+## Actual
+
+## Environment
+```
+
+---
+
+## Spike
+
+**Hierarchy:** standalone or child of Epic
+
+### Issue Type
+
+Org-level issue type: `Spike` (node ID: `IT_kwDODFcis84CBK-7`)
+
+### Fields
+
+| Field      | Kind                   | Node ID                        | Type          | Values / format                      |
+|:-----------|:-----------------------|:-------------------------------|:--------------|:-------------------------------------|
+| `priority` | Org-level issue field  | `IFSS_kgDOAopeGg`              | Single-select | P0 \| P1 \| P2 \| P3                 |
+| `time-box` | Org-level issue field  | `IFT_kgDOAopn2A`               | Text          | Days allocated (e.g. `2d`, `1 week`) |
+| `parent`   | Project field (native) | `PVTF_lADODFcis84BY-C4zhUADu4` | Parent issue  | `Parent #<n>`                        |
+
+**Priority options:** see Epic section above.
+
+### Statuses
+
+`Status` Project field (single-select, node ID: `PVTSSF_lADODFcis84BY-C4zhUADuc`):
+
+| Status        | Option ID  |
+|:--------------|:-----------|
+| `backlog`     | `f75ad846` |
+| `ready`       | `6479c4dc` |
+| `in-progress` | `0d8b05a3` |
+| `done`        | `8f8e8157` |
+
+### Body template
+
+```md
+## Goal
+
+## Time box
+
+## Findings
+```

--- a/docs/agents/pull-requests.md
+++ b/docs/agents/pull-requests.md
@@ -1,0 +1,13 @@
+# Pull Request Config
+
+## Settings
+
+- **Target branch:** main
+- **Allow direct push to target branch:** false
+- **Draft by default:** false
+
+## PR Template
+
+- **Level:** org
+- **Path:** .github/PULL_REQUEST_TEMPLATE.md
+- **Repo:** dnd-mapp/.github

--- a/package.json
+++ b/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "dma-platform",
+  "version": "0.0.0",
+  "description": "Monorepo for the D&D Mapp platform — libraries and applications powering character management, campaign tools, and Virtual Tabletop sessions for D&D 5e.",
+  "license": "MIT",
+  "private": true,
+  "scripts": {
+    "format": "prettier -w .",
+    "format-check": "prettier -l ."
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dnd-mapp/dma-platform.git"
+  },
+  "engines": {
+    "node": "24.16.0"
+  },
+  "devEngines": {
+    "runtime": {
+      "name": "node",
+      "version": "24.16.0"
+    },
+    "packageManager": [
+      {
+        "name": "pnpm",
+        "version": "10.34.1",
+        "onFail": "error"
+      },
+      {
+        "name": "npm",
+        "version": "11.13.0",
+        "onFail": "warn"
+      }
+    ]
+  },
+  "devDependencies": {
+    "prettier": "~3.8.3",
+    "prettier-plugin-organize-imports": "~4.3.0"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,49 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      prettier:
+        specifier: ~3.8.3
+        version: 3.8.3
+      prettier-plugin-organize-imports:
+        specifier: ~4.3.0
+        version: 4.3.0(prettier@3.8.3)(typescript@6.0.3)
+
+packages:
+
+  prettier-plugin-organize-imports@4.3.0:
+    resolution: {integrity: sha512-FxFz0qFhyBsGdIsb697f/EkvHzi5SZOhWAjxcx2dLt+Q532bAlhswcXGYB1yzjZ69kW8UoadFBw7TyNwlq96Iw==}
+    peerDependencies:
+      prettier: '>=2.0'
+      typescript: '>=2.9'
+      vue-tsc: ^2.1.0 || 3
+    peerDependenciesMeta:
+      vue-tsc:
+        optional: true
+
+  prettier@3.8.3:
+    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+snapshots:
+
+  prettier-plugin-organize-imports@4.3.0(prettier@3.8.3)(typescript@6.0.3):
+    dependencies:
+      prettier: 3.8.3
+      typescript: 6.0.3
+
+  prettier@3.8.3: {}
+
+  typescript@6.0.3: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,8 +1,8 @@
 # Workspace settings
 packages:
-    - 'apps/*'
-    - 'packages/*'
-    - '!dist/**/*'
+  - 'apps/*'
+  - 'packages/*'
+  - '!dist/**/*'
 
 # Dependency Resolution
 minimumReleaseAge: 4320 # 3 days
@@ -27,7 +27,6 @@ managePackageManagerVersions: false
 ignoreDepScripts: true
 verifyDepsBeforeRun: error
 strictDepBuilds: true
-
 
 # Other Settings
 savePrefix: '~'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,33 @@
+# Workspace settings
+packages:
+    - 'apps/*'
+    - 'packages/*'
+    - '!dist/**/*'
+
+# Dependency Resolution
+minimumReleaseAge: 4320 # 3 days
+minimumReleaseAgeExclude:
+  - '@dnd-mapp'
+trustPolicy: no-downgrade
+trustPolicyExclude:
+  - '@dnd-mapp'
+trustPolicyIgnoreAfter: 10080 # 7 days
+blockExoticSubdeps: true
+
+# Peer Dependency Settings
+strictPeerDependencies: true
+
+# CLI Settings
+engineStrict: true
+packageManagerStrict: true
+packageManagerStrictVersion: true
+managePackageManagerVersions: false
+
+# Build Settings
+ignoreDepScripts: true
+verifyDepsBeforeRun: error
+strictDepBuilds: true
+
+
+# Other Settings
+savePrefix: '~'


### PR DESCRIPTION
## Summary

### Context

The repository was an empty shell with only a LICENSE and README. This PR bootstraps it as a functioning pnpm monorepo with consistent tooling, formatting enforcement, and CI.

### Changes

- Added `package.json` with `engines`, `devEngines`, versioned dependencies, and workspace metadata; `pnpm-workspace.yaml` declaring `apps/*` and `packages/*` workspaces with strict engine and security settings.
- Configured Prettier with `prettier-plugin-organize-imports` and formatting overrides for YAML/JSON files; extended `.prettierignore` to cover generated and IDE files.
- Extended `.gitattributes` with LF enforcement for new file types and `linguist-generated` markers for the lockfile and JetBrains run configs; expanded `.gitignore` with `node_modules` and editor paths.
- Added VS Code workspace settings (format-on-save, Prettier as default formatter, extension recommendation) and JetBrains run configurations for the `format` and `format-check` scripts.
- Added two GitHub Actions workflows (`pull-request`, `push-main`) backed by two composite actions (`setup-workspace`, `ci`) — all external actions pinned by commit SHA with version comments.
- Updated README with CI and version badges, a setup guide covering prerequisites and editor configuration; added ADR 0001 documenting the decision to use mise for toolchain version management.

## Test Plan

- [x] Run `mise install` and confirm Node 24.16.0 and pnpm 10.34.1 activate.
- [x] Run `pnpm install` and confirm the lockfile is unchanged.
- [x] Run `pnpm format-check` and confirm it passes.
- [x] Open the repo in VS Code and confirm the Prettier extension recommendation appears and format-on-save works.