### PR TITLE
Add unit-test composite action with code coverage upload

### DIFF
--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -16,13 +16,8 @@ runs:
           shell: bash
           run: pnpm --filter @dnd-mapp/realm build
 
-        - name: Install Playwright browsers
-          shell: bash
-          run: pnpm playwright-install
-
         - name: Unit tests
-          shell: bash
-          run: pnpm --filter @dnd-mapp/realm test-ci
+          uses: ./.github/actions/unit-test
 
         - name: E2E tests
           shell: bash

--- a/.github/actions/unit-test/action.yml
+++ b/.github/actions/unit-test/action.yml
@@ -1,0 +1,20 @@
+name: Unit tests
+description: Runs unit tests and uploads code coverage results.
+
+runs:
+    using: composite
+    steps:
+        - name: Install Playwright browsers
+          shell: bash
+          run: pnpm playwright-install
+
+        - name: Run unit tests
+          shell: bash
+          run: pnpm --filter @dnd-mapp/realm test-ci
+
+        - name: Upload code coverage
+          uses: actions/upload-code-coverage@abb5995db9e0199b0e2bb9dbd136fce4cb1ec4d3 # v1.3.0
+          with:
+              file: coverage/apps/realm/cobertura-coverage.xml
+              language: javascript
+              label: realm

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -13,6 +13,7 @@ jobs:
         runs-on: ubuntu-latest
         permissions:
             contents: read
+            code-quality: write
         steps:
             - name: Checkout
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -14,6 +14,7 @@ jobs:
         runs-on: ubuntu-latest
         permissions:
             contents: read
+            code-quality: write
         steps:
             - name: Checkout
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/apps/realm/vitest.config.mts
+++ b/apps/realm/vitest.config.mts
@@ -20,7 +20,7 @@ export default defineConfig({
             enabled: true,
             exclude: ['main.ts', '**/config/*.ts', '**/test/**/*'],
             provider: 'v8',
-            reporter: ['text-summary', 'html'],
+            reporter: ['text-summary', 'html', 'cobertura'],
             reportOnFailure: true,
             reportsDirectory: '../../coverage/apps/realm',
             thresholds: {


### PR DESCRIPTION
## Summary

### Context

The platform needed to report code coverage results on pull requests. GitHub Code Coverage accepts Cobertura XML reports and displays per-file coverage diffs as a bot comment, making it easier for reviewers to spot untested code before merging.

### Changes

- Added `cobertura` to the `realm` Vitest coverage reporters so the test run produces a Cobertura XML report alongside the existing HTML output.
- Added a new `.github/actions/unit-test` composite action that installs Playwright browsers, runs the `@dnd-mapp/realm` unit tests, and uploads the resulting Cobertura XML to GitHub Code Coverage with the label `realm`.
- Updated `.github/actions/ci` to delegate to the new `unit-test` action, removing the now-redundant inline `playwright-install` and `test-ci` steps.
- Added the `code-quality: write` permission to both the `pull-request` and `push-main` workflows, required by `actions/upload-code-coverage`.

## Test Plan

- [x] Open a PR and confirm the `github-code-quality[bot]` posts a coverage summary comment labelled `realm`.
- [x] Confirm all CI checks still pass: formatting, Markdown lint, build, unit tests, and E2E tests.
- [x] Confirm coverage thresholds (80% branches, functions, lines, statements) are still enforced.