### PR TITLE
Document Sigil and Arcane UI packages; fix agent config IDs

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -22,9 +22,24 @@ The main frontend client application (`apps/realm`). A single Angular SPA used b
 
 The custom NestJS authentication server (`apps/gatekeeper`). Issues and validates tokens for all platform apps. The single authority on User identity and session validity.
 
+## Sigil
+
+The platform's design token library (`packages/sigil`). Provides the visual language of the platform — colors, typography, spacing, and other design primitives — as SCSS variables and CSS custom properties. Supports theming via a three-layer token system. Has no Angular dependency. Consumed by both Arcane UI components and directly by frontend apps.
+
+Owns the **primitive** and **semantic** token layers. Compiles to CSS (custom properties on `:root` and `[data-theme]` selectors). Ships three self-hosted fonts (woff2): Metamorphous (headings), Lora (body), Inconsolata (monospace). Component tokens are owned by Arcane UI and expressed as CSS custom properties so apps can override them via the cascade.
+
 ## Arcane UI
 
-The custom Angular component and design system library (`packages/arcane-ui`). No third-party component framework — fully custom-built to support the platform's fantasy aesthetic. Consumed by Realm.
+A shared Angular library (`packages/arcane-ui`) providing generic, reusable UI components and services. Not tied to any visual theme — usable across multiple frontend apps in their own context. No third-party component framework. Components are documented and explored via co-located Storybook stories (Vite builder, documentation only). Unit tests follow the same pattern as Realm: Vitest in browser mode with Playwright and Angular CDK harnesses.
+
+Exposes six secondary entry points:
+
+- **`components`** — reusable UI components.
+- **`config`** — generic `ConfigService<T>` for loading typed JSON config at bootstrap via `APP_INITIALIZER`.
+- **`http`** — `HttpClient` wrapper and generic base services that resolve backend base URLs via `ConfigService`.
+- **`storage`** — browser storage abstractions.
+- **`theming`** — `ThemeService` managing light/dark mode, defaulting to `prefers-color-scheme`, user-overridable.
+- **`testing`** — CDK harnesses for Arcane UI components, for use in consumer app tests.
 
 ## Virtual Tabletop (VTT)
 

--- a/docs/adr/0007-sigil-as-separate-design-token-package.md
+++ b/docs/adr/0007-sigil-as-separate-design-token-package.md
@@ -1,0 +1,26 @@
+# ADR 0007: Sigil as a separate design token package
+
+- **Status:** Accepted
+- **Date:** 2026-05-30
+
+## Context
+
+The platform needs a design token layer — colors, typography, spacing, and other design primitives expressed as CSS custom properties — alongside a shared Angular component library (Arcane UI). The conventional approach is to bundle tokens and components in one package.
+
+Two consumer patterns make that bundling problematic:
+
+1. Frontend apps (e.g. Realm) need to consume design tokens directly in their own stylesheets, independently of any specific component. Forcing apps to import tokens through an Angular library adds an unnecessary Angular dependency to what is a pure CSS concern.
+2. A build-time SCSS pipeline and a runtime Angular library have different build toolchains. Combining them in one package requires either compromising both or maintaining two separate build steps under one roof.
+
+## Decision
+
+Design tokens are owned by **Sigil** (`packages/sigil`) — a standalone package with no Angular dependency. Sigil owns the primitive and semantic token layers of the three-layer token system, ships three self-hosted fonts (Metamorphous, Lora, Inconsolata), and compiles SCSS to CSS using the `sass` CLI. It has no build-time link to any Angular toolchain.
+
+Arcane UI (`packages/arcane-ui`) owns the component token layer. Component tokens are defined as CSS custom properties so apps can override them via the cascade without touching Sigil or Arcane UI internals.
+
+## Consequences
+
+- Sigil can be consumed by any frontend regardless of framework — Angular, or any future non-Angular app in the platform.
+- Apps import Sigil's compiled CSS directly for the semantic layer, and reference Arcane UI's component tokens only when they need to override them.
+- The token authoring workflow is split: primitive/semantic tokens are edited in Sigil, component tokens are edited in Arcane UI. This is an intentional seam, not an oversight.
+- Sigil's build step (`sass` CLI) is separate from and simpler than Arcane UI's `ng-packagr` build. They are never coupled.

--- a/docs/agents/issue-types.md
+++ b/docs/agents/issue-types.md
@@ -17,12 +17,14 @@ Org-level issue type: `Epic` (node ID: `IT_kwDODFcis84CBKdR`)
 
 **Priority options** (org-level issue field `IFSS_kgDOAopeGg`):
 
-| Value | ID         | Description                                                 |
-|:------|:-----------|:------------------------------------------------------------|
-| `P0`  | `74587961` | Drop everything — blocking critical path or a live incident |
-| `P1`  | `74587962` | High priority — must be addressed this quarter              |
-| `P2`  | `74587963` | Normal priority — planned and scheduled                     |
-| `P3`  | `74587964` | Low priority — nice to have, no firm commitment             |
+> **GraphQL note:** Use the `IFSSO_` node IDs below with `singleSelectOptionId`. REST integer IDs do not work with the GraphQL `updateIssueFieldValue` mutation.
+
+| Value | ID                 | Description                                                 |
+|:------|:-------------------|:------------------------------------------------------------|
+| `P0`  | `IFSSO_kgDOBHIfOQ` | Drop everything — blocking critical path or a live incident |
+| `P1`  | `IFSSO_kgDOBHIfOg` | High priority — must be addressed this quarter              |
+| `P2`  | `IFSSO_kgDOBHIfOw` | Normal priority — planned and scheduled                     |
+| `P3`  | `IFSSO_kgDOBHIfPA` | Low priority — nice to have, no firm commitment             |
 
 ### Statuses
 
@@ -60,9 +62,14 @@ Org-level issue type: `Story` (node ID: `IT_kwDODFcis84CBKrx`)
 |:-------------|:-----------------------|:-------------------------------|:--------------|:----------------------------|
 | `priority`   | Org-level issue field  | `IFSS_kgDOAopeGg`              | Single-select | P0 \| P1 \| P2 \| P3        |
 | `estimation` | Org-level issue field  | `IFN_kgDOAoptyA`               | Number        | 1 \| 2 \| 3 \| 5 \| 8 \| 13 |
-| `parent`     | Project field (native) | `PVTF_lADODFcis84BY-C4zhUADu4` | Parent issue  | `Parent #<n>`               |
+| `parent`     | Project field (native) | `PVTF_lADODFcis84BY-C4zhUADu4` | Parent issue  | use `addSubIssue` mutation  |
 
 **Priority options:** see Epic section above.
+
+> **Note — parent field:** Set natively via `addSubIssue` mutation — do not
+> include `Parent #<n>` in the issue body.
+>
+> **GraphQL note — Story Points:** Set via `updateIssueFieldValue` with `issueField: { fieldId: "IFN_kgDOAoptyA", numberValue: <n> }`. The argument is `numberValue` (Float), not `number`.
 
 ### Statuses
 
@@ -143,12 +150,12 @@ Org-level issue type: `Bug` (node ID: `IT_kwDODFcis84CBK3a`)
 
 **Severity options** (org-level issue field `IFSS_kgDOAoplog`):
 
-| Value | ID         | Description                                                           |
-|:------|:-----------|:----------------------------------------------------------------------|
-| `S0`  | `74591344` | Data loss, corruption, or complete feature failure with no workaround |
-| `S1`  | `74591345` | Core flow broken; workaround exists but is painful                    |
-| `S2`  | `74591346` | Degraded experience; reasonable workaround available                  |
-| `S3`  | `74591347` | Cosmetic or minor issue; does not impact functionality                |
+| Value | ID                 | Description                                                           |
+|:------|:-------------------|:----------------------------------------------------------------------|
+| `S0`  | `IFSSO_kgDOBHIscA` | Data loss, corruption, or complete feature failure with no workaround |
+| `S1`  | `IFSSO_kgDOBHIscQ` | Core flow broken; workaround exists but is painful                    |
+| `S2`  | `IFSSO_kgDOBHIscg` | Degraded experience; reasonable workaround available                  |
+| `S3`  | `IFSSO_kgDOBHIscw` | Cosmetic or minor issue; does not impact functionality                |
 
 ### Statuses
 


### PR DESCRIPTION
## Summary

### Context

This PR captures architectural design decisions from a planning session for two new packages: Sigil (a standalone design token library) and Arcane UI (a generic Angular component library). Both packages needed documentation in CONTEXT.md and a formal ADR to record the decision to keep them as separate packages. Separately, the issue-types agent config had incorrect GraphQL node IDs that caused field-setting failures when creating GitHub issues.

### Changes

- Adds a Sigil entry to CONTEXT.md documenting its scope, three-layer SCSS token system, `[data-theme]` and `prefers-color-scheme` theming, and three self-hosted fonts (Metamorphous, Lora, Inconsolata).
- Corrects and expands the Arcane UI entry to reflect the six secondary entry points (components, config, http, storage, theming, testing), co-located Storybook documentation setup, and Vitest browser-mode test approach.
- Adds ADR 0007, recording the decision to separate design tokens (Sigil) from the component library (Arcane UI) and the reasoning behind that boundary.
- Fixes `docs/agents/issue-types.md`: replaces REST integer IDs with correct `IFSSO_` node IDs for priority and severity fields; adds usage notes for the `addSubIssue` parent-field mutation and the `numberValue` argument for story points.

## Test Plan

- [x] CONTEXT.md renders correctly and both entries accurately describe the packages.
- [x] ADR 0007 follows the established ADR format and is consistent with earlier records.
- [x] Issue creation with the updated agent config correctly sets priority, severity, and story points using the corrected node IDs.