### PR TITLE
feat(sigil): Scaffold sigil workspace package

### DIFF
--- a/packages/sigil/README.md
+++ b/packages/sigil/README.md
@@ -1,0 +1,6 @@
+# @dnd-mapp/sigil
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](../../LICENSE)
+[![node: >=24.0.0](https://img.shields.io/badge/node-%3E%3D24.0.0-339933?logo=nodedotjs&logoColor=white)](package.json)
+
+`@dnd-mapp/sigil` is D&D Mapp's design token library. It defines the visual language — colors, typography, spacing, and other design primitives — as SCSS variables and CSS custom properties. Owns the primitive and semantic layers of a three-layer token system, with theming support via CSS custom properties on `:root` and `[data-theme]` selectors. Framework-agnostic — consumable by any frontend.

--- a/packages/sigil/package.json
+++ b/packages/sigil/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@dnd-mapp/sigil",
+  "version": "0.0.0",
+  "description": "Design token library for the D&D Mapp platform — colors, typography, spacing, and other design primitives as SCSS variables and CSS custom properties.",
+  "keywords": [
+    "design-tokens",
+    "scss",
+    "css",
+    "theming"
+  ],
+  "license": "MIT",
+  "private": true,
+  "engines": {
+    "node": ">=24.0.0"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,6 +152,8 @@ importers:
         specifier: '>=8.0.0'
         version: 8.60.0(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3)
 
+  packages/sigil: {}
+
   packages/stylelint-config:
     dependencies:
       stylelint:


### PR DESCRIPTION
## Summary

### Context

Issue #21 calls for introducing `packages/sigil` as a pnpm workspace package. Sigil is D&D Mapp's design token library — it will provide the platform's visual language (colors, typography, spacing) as SCSS variables and CSS custom properties with no Angular dependency. Prior to this, the `packages/sigil` directory did not exist.

### Changes

Adds `packages/sigil/` with a `package.json` carrying metadata only (name, description, keywords, license, engines) — no scripts or dependencies, which are deferred to follow-up issues #22 and #23. A `README.md` introduces the package with badges and a brief description. The lockfile is updated to register the new workspace member.

## Test Plan

- [x] Run `pnpm ls -r --depth -1` and confirm `@dnd-mapp/sigil@0.0.0` appears in the workspace listing.
- [x] Confirm `packages/sigil/package.json` has no `scripts`, `dependencies`, or `devDependencies` fields.

Closes: #21