### PR TITLE
chore(moonrepo): Install @moonrepo/cli and scaffold .moon/

### DIFF
--- a/.github/actions/setup-workspace/action.yml
+++ b/.github/actions/setup-workspace/action.yml
@@ -26,3 +26,8 @@ runs:
           env:
               HUSKY: 0
           run: pnpm install
+
+        - name: Verify moon installation
+          if: inputs.install-dependencies == 'true'
+          shell: bash
+          run: pnpm moon --version

--- a/.moon/toolchain.yml
+++ b/.moon/toolchain.yml
@@ -1,0 +1,1 @@
+# Configured in #52

--- a/.moon/workspace.yml
+++ b/.moon/workspace.yml
@@ -1,0 +1,1 @@
+# Configured in #52

--- a/docs/adr/0005-parallel-ci-with-gated-e2e.md
+++ b/docs/adr/0005-parallel-ci-with-gated-e2e.md
@@ -1,6 +1,6 @@
 # ADR 0005: Parallel CI jobs with E2E gated behind all other checks
 
-- **Status:** Accepted
+- **Status:** Superseded by [ADR 0008](0008-moonrepo-for-task-orchestration-and-affected-ci.md)
 - **Date:** 2026-05-29
 
 ## Context

--- a/docs/adr/0008-moonrepo-for-task-orchestration-and-affected-ci.md
+++ b/docs/adr/0008-moonrepo-for-task-orchestration-and-affected-ci.md
@@ -1,0 +1,43 @@
+# ADR 0008: Use moonrepo for task orchestration and affected-only CI runs
+
+- **Status:** Accepted
+- **Date:** 2026-05-30
+
+## Context
+
+As the monorepo grows, running every lint, build, test, and E2E task on every CI trigger becomes wasteful. A PR that changes only `packages/sigil` should not need to rebuild and retest `apps/realm`, `apps/gatekeeper`, or the E2E suite — unless the change transitively affects those projects.
+
+The current CI (`.github/workflows/pull-request.yml`, `.github/workflows/push-main.yml`) runs all tasks unconditionally across all projects. There is no task graph, no dependency-aware scheduling, and no caching. Parallelism is achieved by manually splitting tasks into separate GitHub Actions jobs, which requires re-running the workspace setup step in each job.
+
+Several task orchestration tools were considered:
+
+- **Nx** — deep Angular CLI integration (reads `angular.json` for the project graph), but adds significant tooling weight and tightly couples the repo to the Nx ecosystem.
+- **Turborepo** — lightweight and pnpm-native, but affected detection is based solely on `package.json` workspace dependencies. This repo does not declare intra-monorepo dependencies in `package.json` (the Angular build resolves them via `tsconfig` path aliases), so Turborepo's affected detection would not work without first restructuring all `package.json` files.
+- **moonrepo** — task graph is declared explicitly in per-project `moon.yml` files (`dependsOn`), independent of `package.json`. Works correctly even when workspace packages do not formally declare each other as dependencies. Provides affected-only task execution, task-level caching, and first-class CI integration.
+- **Status quo** — keep manual GitHub Actions jobs, add new jobs by hand as the monorepo grows. Does not scale; duplicate setup steps per job; no affected detection.
+
+## Decision
+
+Adopt **moonrepo** for task orchestration and affected-only CI runs, with the following configuration choices:
+
+**Toolchain:** Set `node.version: inherit` in `.moon/toolchain.yml`. Moon defers to whatever Node version is active in the shell. Mise continues to activate the correct version (see ADR 0001). Moon does not manage the toolchain.
+
+**Project dependency graph:** Declare all project and task dependencies explicitly via `dependsOn` in each project's `moon.yml`. Do not rely on `package.json` workspace dependency auto-detection, as intra-monorepo dependencies are not declared there.
+
+**Task definitions:** Moon tasks wrap existing `package.json` scripts (`command: "pnpm run <script>"`). The scripts in each `package.json` remain the canonical command definitions. Moon adds the dependency graph and affected-detection metadata on top.
+
+**Workspace-level tasks:** A root moon project (path `.`) owns tasks that are not tied to any specific package — `format` (Prettier check), `lint:ts` (TypeScript root check), and `lint:md` (Markdown lint). These tasks have broadly-scoped inputs so moon can correctly compute affected status.
+
+**CI structure:** Replace the multi-job GitHub Actions workflows with a single `moon ci --affected` job. The E2E gate (previously enforced by a `needs:` dependency between GitHub Actions jobs) is enforced by declaring `dependsOn` on the `e2e/realm:test` moon task, pointing at `realm:build`, `realm:lint`, and `realm:test`. Moon will not schedule the E2E task until all declared dependencies succeed. This supersedes ADR 0005.
+
+**Remote caching:** Disabled for now. Moonbase (moon's hosted remote cache) has been sunset. A self-hosted alternative using `bazel-remote` is under investigation (see `docs/handoffs/bazel-remote-cache-investigation.md`). Until a solution is adopted, moon provides affected-only task execution but no cross-run cache persistence in CI.
+
+## Consequences
+
+- CI workflows are simplified to a single job per workflow, eliminating duplicate workspace setup steps.
+- Only tasks for projects affected by a given change are executed. A change to `packages/sigil` triggers tasks for sigil, Arcane UI, Realm, and the Realm E2E suite — and nothing else.
+- The E2E gate is maintained: moon will not run `e2e/realm:test` if any of its `dependsOn` tasks fail, preserving the intent of ADR 0005.
+- Each project requires a `moon.yml` file. New projects must declare their `dependsOn` relationships at creation time; omitting them will cause moon to treat the project as isolated and miss affected propagation.
+- The project dependency graph is maintained in `moon.yml` files rather than `package.json`. This is a second place where dependencies are expressed (alongside `tsconfig` path aliases), requiring both to be kept in sync when a new inter-project dependency is introduced.
+- Without remote caching, CI always runs cold. The affected-only model reduces the number of tasks executed, but individual task results are not reused across runs.
+- `moon ci --affected` compares against the base branch ref by default. Both `pull-request` and `push-main` workflows use the same command; affected detection on `push-main` runs against the previous commit on main.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "prepare": "husky",
     "ng": "ng",
+    "moon": "moon",
     "commitlint": "commitlint",
     "lint:md": "markdownlint-cli2 --config .markdownlint-cli2.json",
     "lint:ts": "eslint .",
@@ -61,6 +62,7 @@
     "@commitlint/config-conventional": "~21.0.1",
     "@dnd-mapp/eslint-config": "workspace:*",
     "@dnd-mapp/stylelint-config": "workspace:*",
+    "@moonrepo/cli": "~2.2.5",
     "@playwright/test": "~1.60.0",
     "@types/node": "~24.12.4",
     "@vitest/browser-playwright": "~4.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       '@dnd-mapp/stylelint-config':
         specifier: workspace:*
         version: link:packages/stylelint-config
+      '@moonrepo/cli':
+        specifier: ~2.2.5
+        version: 2.2.5
       '@playwright/test':
         specifier: ~1.60.0
         version: 1.60.0
@@ -1085,6 +1088,49 @@ packages:
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
+
+  '@moonrepo/cli@2.2.5':
+    resolution: {integrity: sha512-MZPXJ7pvfcC77jedFPxwW4Z4XCPzeuBMmbVjRDFXq13bnyAYcaH5kdxkvyxX4WHeEHWyWuustOaJowZo3Q/SxA==}
+    hasBin: true
+
+  '@moonrepo/core-linux-arm64-gnu@2.2.5':
+    resolution: {integrity: sha512-61ajwr3oxCAC0vp879LgKzml3pu+kJ0xMd2Tr1fFMuqp+Xp9k+41VOaTlW7m3vhNQCTVuFFGKxh8KUeAtJk//w==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@moonrepo/core-linux-arm64-musl@2.2.5':
+    resolution: {integrity: sha512-8gcRf1B+jxbdy4rdQzfXSg37ECsiThCKYHYYXfe4etzcC6CQjmmYeC7OxF+gxWK0mL6UbpuKso8zOcqSbYzjYw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@moonrepo/core-linux-x64-gnu@2.2.5':
+    resolution: {integrity: sha512-kqZppmKKzdStXbOpWUS+rQlJiowO0ItwWP74oqJVpwUewAjqB2WLwG6IvhSAVHrVhC+9OCGm0g4iAESQBAEh2w==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@moonrepo/core-linux-x64-musl@2.2.5':
+    resolution: {integrity: sha512-UxyYR+SJ7er7Skb60saphEWsPN+oecqDIrNxdAYy+3Li7G9jzBK0j59Jj7j2c0pjlBSKao06DGmfM6WuBlE8eg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@moonrepo/core-macos-arm64@2.2.5':
+    resolution: {integrity: sha512-DpvFXa/N4rc/vJygE6JBL1pW0DtX00h07xruWQYjdeOuv3RQClRQSwZJNJmGZKhZus4g/LccHgEGvRdu9IMC4w==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@moonrepo/core-macos-x64@2.2.5':
+    resolution: {integrity: sha512-J4udAbRTnK+EarHu7nIKm2j5t4CY0I9hfoyGOSU9bsC3n91//YNrixPnCe34IA4irArNzqPnoDXlQv/v5mG8Pg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@moonrepo/core-windows-x64-msvc@2.2.5':
+    resolution: {integrity: sha512-yYPMsOHL5daEPSTMp2JP+YrwmGjeu+Kp25UmRnllGDmofkCu4Gcv3ct6ljK+u1+W6q2Jc2ooY7eZ14dnKJnlug==}
+    cpu: [x64]
+    os: [win32]
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4':
     resolution: {integrity: sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==}
@@ -5156,6 +5202,39 @@ snapshots:
       zod-to-json-schema: 3.25.2(zod@4.3.6)
     transitivePeerDependencies:
       - supports-color
+
+  '@moonrepo/cli@2.2.5':
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      '@moonrepo/core-linux-arm64-gnu': 2.2.5
+      '@moonrepo/core-linux-arm64-musl': 2.2.5
+      '@moonrepo/core-linux-x64-gnu': 2.2.5
+      '@moonrepo/core-linux-x64-musl': 2.2.5
+      '@moonrepo/core-macos-arm64': 2.2.5
+      '@moonrepo/core-macos-x64': 2.2.5
+      '@moonrepo/core-windows-x64-msvc': 2.2.5
+
+  '@moonrepo/core-linux-arm64-gnu@2.2.5':
+    optional: true
+
+  '@moonrepo/core-linux-arm64-musl@2.2.5':
+    optional: true
+
+  '@moonrepo/core-linux-x64-gnu@2.2.5':
+    optional: true
+
+  '@moonrepo/core-linux-x64-musl@2.2.5':
+    optional: true
+
+  '@moonrepo/core-macos-arm64@2.2.5':
+    optional: true
+
+  '@moonrepo/core-macos-x64@2.2.5':
+    optional: true
+
+  '@moonrepo/core-windows-x64-msvc@2.2.5':
+    optional: true
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4':
     optional: true


### PR DESCRIPTION
## Summary

### Context

The platform monorepo has adopted moonrepo for task orchestration and affected-only CI runs (ADR 0008, #48). This PR is the first implementation step: getting moon installed and available in CI before workspace configuration (#52) and per-project task definitions (#51) land.

### Changes

- Adds `@moonrepo/cli ~2.2.5` as a workspace root devDependency with a `moon` script in `package.json` so `pnpm moon` resolves the locally installed binary.
- Creates `.moon/workspace.yml` and `.moon/toolchain.yml` as minimal valid stubs. Full configuration follows in #52.
- Adds a temporary `moon --version` verification step to the `setup-workspace` action to confirm moon is available in CI after `pnpm install`. This step will be removed when the full CI integration lands in #53.
- Adds ADR 0008 documenting the moonrepo adoption decision and marks ADR 0005 as superseded — the E2E gate moves from GitHub Actions `needs:` to moon task `dependsOn`.

## Test Plan

- [x] CI passes on this PR.
- [x] The "Verify moon installation" step in setup-workspace prints `moon 2.2.5`.

Closes: #50