### PR TITLE
feat(moonrepo): Configure workspace and toolchain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ coverage/
 reports/
 
 .husky/_
+.moon/cache/

--- a/.moon/toolchain.yml
+++ b/.moon/toolchain.yml
@@ -1,1 +1,8 @@
-# Configured in #52
+$schema: 'https://moonrepo.dev/schemas/toolchain.json'
+
+node:
+    version: 'inherit'
+    packageManager: 'pnpm'
+
+pnpm:
+    version: 'inherit'

--- a/.moon/workspace.yml
+++ b/.moon/workspace.yml
@@ -1,1 +1,12 @@
-# Configured in #52
+$schema: 'https://moonrepo.dev/schemas/workspace.json'
+
+projects:
+    realm: 'apps/realm'
+    sigil: 'packages/sigil'
+    eslint-config: 'packages/eslint-config'
+    stylelint-config: 'packages/stylelint-config'
+    realm-e2e: 'e2e/realm'
+    root: '.'
+
+vcs:
+    defaultBranch: 'main'

--- a/apps/realm/moon.yml
+++ b/apps/realm/moon.yml
@@ -1,5 +1,9 @@
 $schema: 'https://moonrepo.dev/schemas/project.json'
 
+language: 'typescript'
+stack: 'frontend'
+layer: 'application'
+
 dependsOn:
     - sigil
     - eslint-config

--- a/e2e/realm/moon.yml
+++ b/e2e/realm/moon.yml
@@ -1,5 +1,9 @@
 $schema: 'https://moonrepo.dev/schemas/project.json'
 
+language: 'typescript'
+stack: 'frontend'
+layer: 'automation'
+
 dependsOn:
     - realm
     - eslint-config

--- a/moon.yml
+++ b/moon.yml
@@ -1,5 +1,9 @@
 $schema: 'https://moonrepo.dev/schemas/project.json'
 
+language: 'javascript'
+stack: 'unknown'
+layer: 'tool'
+
 tasks:
     format-check:
         command: 'pnpm format-check'

--- a/packages/eslint-config/moon.yml
+++ b/packages/eslint-config/moon.yml
@@ -1,5 +1,9 @@
 $schema: 'https://moonrepo.dev/schemas/project.json'
 
+language: 'javascript'
+stack: 'unknown'
+layer: 'configuration'
+
 tasks:
     lint-ts:
         command: 'pnpm lint-ts'

--- a/packages/sigil/moon.yml
+++ b/packages/sigil/moon.yml
@@ -1,1 +1,5 @@
 $schema: 'https://moonrepo.dev/schemas/project.json'
+
+language: 'scss'
+stack: 'frontend'
+layer: 'library'

--- a/packages/stylelint-config/moon.yml
+++ b/packages/stylelint-config/moon.yml
@@ -1,5 +1,9 @@
 $schema: 'https://moonrepo.dev/schemas/project.json'
 
+language: 'javascript'
+stack: 'unknown'
+layer: 'configuration'
+
 tasks:
     lint-ts:
         command: 'pnpm lint-ts'


### PR DESCRIPTION
## Summary

### Context

As part of adopting moonrepo for task orchestration (#48), the workspace-level configuration files `.moon/workspace.yml` and `.moon/toolchain.yml` need to be populated. Both files existed as empty placeholders before this PR.

### Changes

Configures `.moon/workspace.yml` to register all six workspace projects (`realm`, `sigil`, `eslint-config`, `stylelint-config`, `realm-e2e`, `root`) with their source paths. Also sets `vcs.defaultBranch: main` so `moon ci --affected` compares against the correct base ref (moon defaults to `master`).

Configures `.moon/toolchain.yml` to set `node.version: inherit`, `node.packageManager: pnpm`, and `pnpm.version: inherit`, deferring all toolchain and package manager version management to mise (per ADR 0001). Moon does not manage the toolchain.

Adds `.moon/cache/` to `.gitignore` to prevent moon's task output cache from being committed.

## Test Plan

- [x] Run `pnpm moon project realm` and verify it resolves to `apps/realm` with the correct `dependsOn` entries
- [x] Run `pnpm moon project root` and verify it resolves to `.` with its four tasks
- [x] Run `pnpm moon project realm-e2e` and verify it resolves to `e2e/realm` with the correct `dependsOn`

Closes: #52