### PR TITLE
feat(sigil): Define semantic token layer

### DIFF
--- a/docs/adr/0010-warm-tinted-surface-tokens.md
+++ b/docs/adr/0010-warm-tinted-surface-tokens.md
@@ -1,0 +1,28 @@
+# ADR 0010: Warm-tinted surface tokens for the light theme
+
+- **Status:** Accepted
+- **Date:** 2026-06-01
+
+## Context
+
+The semantic color layer needs a surface family for the light theme default — page backgrounds, wells, cards, and overlays. The obvious choice is the grey scale (`$color-grey-50`/`100`), which is chromatic neutral. The platform's primary brand color is maroon (hue 32°).
+
+## Decision
+
+Surface tokens use the **maroon primitive scale** rather than the grey scale:
+
+- `--color-surface-subtle` → `$color-maroon-100` (93% lightness)
+- `--color-surface-default` → `$color-maroon-50` (97% lightness)
+- `--color-surface-raised` / `--color-surface-overlay` → `$color-white` (99% lightness, hue 32°)
+
+The difference from pure grey is subtle — `$color-maroon-50` is `oklch(97% 0.01 32deg)` versus `$color-grey-50` at `oklch(97% 0.004 0deg)` — but it gives light mode a faint parchment warmth that fits the platform's D&D identity.
+
+For tonal consistency, the white and black primitives also carry hue 32°: `$color-white: oklch(99% 0.006 32deg)` and `$color-black: oklch(8% 0.006 32deg)`.
+
+The grey scale is reserved for text and border tokens, where chromatic neutrality reads more cleanly against warm surfaces.
+
+## Consequences
+
+- Light mode has a cohesive warmth throughout — surface, raised, and overlay layers all share the same hue family.
+- Grey text on a maroon-tinted surface produces a subtle but intentional contrast in hue, avoiding the flat look of grey-on-grey.
+- Dark theme overrides (ADR pending, issue #26) will need to decide independently whether dark surfaces follow the same hue or shift to a cooler neutral.

--- a/docs/adr/0011-spacing-radius-scss-only.md
+++ b/docs/adr/0011-spacing-radius-scss-only.md
@@ -1,0 +1,23 @@
+# ADR 0011: Spacing and radius as SCSS-only primitives
+
+- **Status:** Accepted
+- **Date:** 2026-06-01
+
+## Context
+
+The semantic layer exposes color and typography tokens as CSS custom properties on `:root`. Spacing (`$spacing-1` through `$spacing-16`) and radius (`$radius-sm` through `$radius-full`) exist as SCSS variables in the primitives layer. The question is whether they should also be compiled to `:root` custom properties.
+
+## Decision
+
+Spacing and radius are **not** exposed as CSS custom properties. They remain SCSS variables consumed via `@use` at compile time by Arcane UI and Realm.
+
+## Considered options
+
+- **CSS custom properties** — would allow runtime `calc()` compositions, cascade overrides, and access from non-SCSS consumers.
+- **SCSS-only** — sufficient because all current and planned consumers (Arcane UI, Realm) author styles in SCSS and can `@use` the primitives directly at build time.
+
+## Consequences
+
+- The compiled CSS output is simpler — no spacing or radius properties on `:root`.
+- Any future non-SCSS consumer cannot access these tokens without re-implementing them or without this decision being revisited.
+- Density variants or responsive spacing overrides driven by runtime custom property swaps are not possible under this model. If that need arises, the spacing tokens should be promoted to the CSS custom property surface.

--- a/packages/sigil/README.md
+++ b/packages/sigil/README.md
@@ -5,3 +5,126 @@
 [![sass: ~1.100.0](https://img.shields.io/badge/sass-~1.100.0-CC6699?logo=sass&logoColor=white)](../../package.json)
 
 `@dnd-mapp/sigil` is D&D Mapp's design token library. It defines the visual language — colors, typography, spacing, and other design primitives — as SCSS variables and CSS custom properties. Owns the primitive and semantic layers of a three-layer token system, with theming support via CSS custom properties on `:root` and `[data-theme]` selectors. Framework-agnostic — consumable by any frontend.
+
+## Consuming semantic tokens
+
+Semantic tokens are compiled to CSS custom properties in `index.css`. Load it once as a global stylesheet — do not `@use` it from SCSS, as Sass treats CSS imports as a plain passthrough rather than inlining the content.
+
+In Angular, add it to the `styles` array in `angular.json`:
+
+```json
+{
+    "styles": [
+        "dist/packages/sigil/index.css"
+    ]
+}
+```
+
+Or link it directly in your HTML shell:
+
+```html
+<link rel="stylesheet" href="dist/packages/sigil/index.css">
+```
+
+All semantic tokens are then available as CSS custom properties throughout your stylesheets:
+
+```scss
+.card {
+    background: var(--color-surface-raised);
+    color: var(--color-text-primary);
+    border: 1px solid var(--color-border-default);
+    font-size: var(--typography-size-sm);
+    font-weight: var(--typography-weight-regular);
+    line-height: var(--typography-line-height-normal);
+}
+```
+
+### Available token categories
+
+| Prefix                       | Category           | Example                                                         |
+|:-----------------------------|:-------------------|:----------------------------------------------------------------|
+| `--color-surface-*`          | Background layers  | `default`, `subtle`, `raised`, `overlay`                        |
+| `--color-text-*`             | Text colours       | `primary`, `secondary`, `disabled`, `inverse`, `on-interactive` |
+| `--color-border-*`           | Border colours     | `subtle`, `default`, `strong`                                   |
+| `--color-interactive-*`      | Interactive states | `primary`, `primary-hover`, `primary-active`, `danger`, `focus` |
+| `--typography-size-*`        | Font sizes         | `xs` → `4xl`                                                    |
+| `--typography-weight-*`      | Font weights       | `regular`, `medium`, `semibold`, `bold`                         |
+| `--typography-line-height-*` | Line heights       | `tight`, `snug`, `normal`, `relaxed`                            |
+
+## Consuming semantic tokens in SCSS
+
+For consumers that author styles in SCSS, semantic tokens are also available as SCSS variables that compile to `var()` with a light-theme fallback. This keeps theming intact — the CSS custom property is resolved at runtime — while allowing ergonomic SCSS variable references.
+
+First configure Sigil's dist as an SCSS load path (see [includePaths setup](#includepaths-setup) below), then import:
+
+```scss
+@use 'tokens/color' as *;
+@use 'tokens/typography' as *;
+
+.card {
+    background: $color-surface-raised;
+    color: $color-text-primary;
+    border: 1px solid $color-border-default;
+    font-size: $typography-size-sm;
+    line-height: $typography-line-height-normal;
+}
+```
+
+Each variable compiles to a `var()` with the light-theme primitive as fallback:
+
+```css
+.card {
+    background: var(--color-surface-raised, oklch(99% 0.006 32deg));
+}
+```
+
+`index.css` must still be loaded for dark theme overrides to take effect. The fallback only activates if the custom property is not defined.
+
+### Available token files
+
+| File                | Variables                                                                      |
+|:--------------------|:-------------------------------------------------------------------------------|
+| `tokens/color`      | `$color-surface-*`, `$color-text-*`, `$color-border-*`, `$color-interactive-*` |
+| `tokens/typography` | `$typography-size-*`, `$typography-weight-*`, `$typography-line-height-*`      |
+
+## Consuming spacing and radius primitives
+
+Spacing and radius are SCSS-only — they are not compiled to CSS custom properties. Consume them via `@use` at build time using the same load path setup:
+
+```scss
+@use 'primitives/spacing' as *;
+@use 'primitives/radius' as *;
+
+.button {
+    padding: $spacing-2 $spacing-4;
+    border-radius: $radius-md;
+}
+```
+
+### includePaths setup
+
+Add Sigil's dist to your SCSS load paths. In Angular (`angular.json`):
+
+```json
+{
+    "stylePreprocessorOptions": {
+        "includePaths": [
+            "dist/packages/sigil"
+        ]
+    }
+}
+```
+
+> [!NOTE]
+> The package also exposes a `sass` export condition for toolchains that support Dart Sass's [`NodePackageImporter`](https://sass-lang.com/documentation/js-api/classes/nodepackageimporter/). Angular CLI does not support custom Sass importers and cannot use `pkg:` URLs — `includePaths` is the correct approach for Angular.
+
+### Available primitive files
+
+| File                     | Variables                                             |
+|:-------------------------|:------------------------------------------------------|
+| `primitives/color`       | `$color-{hue}-{step}`, `$color-white`, `$color-black` |
+| `primitives/font-size`   | `$font-size-{xs\|sm\|md\|lg\|xl\|2xl\|3xl\|4xl}`      |
+| `primitives/font-weight` | `$font-weight-{regular\|medium\|semibold\|bold}`      |
+| `primitives/line-height` | `$line-height-{tight\|snug\|normal\|relaxed}`         |
+| `primitives/spacing`     | `$spacing-{1\|2\|3\|4\|5\|6\|8\|10\|12\|16}`          |
+| `primitives/radius`      | `$radius-{sm\|md\|lg\|xl\|full}`                      |

--- a/packages/sigil/package.json
+++ b/packages/sigil/package.json
@@ -9,6 +9,15 @@
     "theming"
   ],
   "license": "MIT",
+  "exports": {
+    ".": "./index.css",
+    "./primitives/*": {
+      "sass": "./primitives/_*.scss"
+    },
+    "./tokens/*": {
+      "sass": "./tokens/_*.scss"
+    }
+  },
   "private": true,
   "engines": {
     "node": ">=24.0.0"

--- a/packages/sigil/scripts/post-build.mjs
+++ b/packages/sigil/scripts/post-build.mjs
@@ -1,4 +1,4 @@
-import { copyFile, mkdir } from 'fs/promises';
+import { cp, mkdir, readFile, writeFile } from 'fs/promises';
 import { resolve } from 'path';
 import { fileURLToPath } from 'url';
 
@@ -8,9 +8,14 @@ const distDir = resolve(pkgDir, '../../dist/packages/sigil');
 async function postBuild() {
     await mkdir(distDir, { recursive: true });
 
+    const pkg = JSON.parse(await readFile(resolve(pkgDir, 'package.json'), 'utf8'));
+    delete pkg.scripts;
+
     await Promise.all([
-        copyFile(resolve(pkgDir, 'package.json'), resolve(distDir, 'package.json')),
-        copyFile(resolve(pkgDir, 'README.md'), resolve(distDir, 'README.md')),
+        writeFile(resolve(distDir, 'package.json'), JSON.stringify(pkg, null, 2) + '\n'),
+        cp(resolve(pkgDir, 'README.md'), resolve(distDir, 'README.md')),
+        cp(resolve(pkgDir, 'src/primitives'), resolve(distDir, 'primitives'), { recursive: true }),
+        cp(resolve(pkgDir, 'src/tokens'), resolve(distDir, 'tokens'), { recursive: true }),
     ]);
 }
 

--- a/packages/sigil/src/index.scss
+++ b/packages/sigil/src/index.scss
@@ -1,2 +1,2 @@
-// Semantic token partials are forwarded here as they are added.
-// Primitives (src/primitives/) are internal — consumed by the semantic layer, not forwarded.
+@forward 'semantics/color';
+@forward 'semantics/typography';

--- a/packages/sigil/src/primitives/_color.scss
+++ b/packages/sigil/src/primitives/_color.scss
@@ -1,3 +1,7 @@
+// White and black — near-absolute with a faint maroon warmth (32°) for tonal consistency with surfaces
+$color-white: oklch(99% 0.006 32deg);
+$color-black: oklch(8% 0.006 32deg);
+
 // Maroon — primary brand
 $color-maroon-50: oklch(97% 0.01 32deg);
 $color-maroon-100: oklch(93% 0.02 32deg);

--- a/packages/sigil/src/primitives/_font-weight.scss
+++ b/packages/sigil/src/primitives/_font-weight.scss
@@ -1,0 +1,4 @@
+$font-weight-regular: 400;
+$font-weight-medium: 500;
+$font-weight-semibold: 600;
+$font-weight-bold: 700;

--- a/packages/sigil/src/primitives/_line-height.scss
+++ b/packages/sigil/src/primitives/_line-height.scss
@@ -1,0 +1,4 @@
+$line-height-tight: 1.2; // headings
+$line-height-snug: 1.4; // subheadings, compact UI
+$line-height-normal: 1.5; // body text
+$line-height-relaxed: 1.75; // long-form reading

--- a/packages/sigil/src/semantics/_color.scss
+++ b/packages/sigil/src/semantics/_color.scss
@@ -1,0 +1,28 @@
+@use '../primitives/color' as *;
+
+:root {
+    // Surface
+    --color-surface-subtle: #{$color-maroon-100};
+    --color-surface-default: #{$color-maroon-50};
+    --color-surface-raised: #{$color-white};
+    --color-surface-overlay: #{$color-white};
+
+    // Text
+    --color-text-primary: #{$color-grey-900};
+    --color-text-secondary: #{$color-grey-600};
+    --color-text-disabled: #{$color-grey-400};
+    --color-text-inverse: #{$color-white};
+    --color-text-on-interactive: #{$color-white};
+
+    // Border
+    --color-border-subtle: #{$color-grey-100};
+    --color-border-default: #{$color-grey-200};
+    --color-border-strong: #{$color-grey-400};
+
+    // Interactive
+    --color-interactive-primary: #{$color-maroon-600};
+    --color-interactive-primary-hover: #{$color-maroon-700};
+    --color-interactive-primary-active: #{$color-maroon-800};
+    --color-interactive-danger: #{$color-red-600};
+    --color-interactive-focus: #{$color-maroon-400};
+}

--- a/packages/sigil/src/semantics/_typography.scss
+++ b/packages/sigil/src/semantics/_typography.scss
@@ -1,0 +1,27 @@
+@use '../primitives/font-size' as *;
+@use '../primitives/font-weight' as *;
+@use '../primitives/line-height' as *;
+
+:root {
+    // Size
+    --typography-size-xs: #{$font-size-xs};
+    --typography-size-sm: #{$font-size-sm};
+    --typography-size-md: #{$font-size-md};
+    --typography-size-lg: #{$font-size-lg};
+    --typography-size-xl: #{$font-size-xl};
+    --typography-size-2xl: #{$font-size-2xl};
+    --typography-size-3xl: #{$font-size-3xl};
+    --typography-size-4xl: #{$font-size-4xl};
+
+    // Weight
+    --typography-weight-regular: #{$font-weight-regular};
+    --typography-weight-medium: #{$font-weight-medium};
+    --typography-weight-semibold: #{$font-weight-semibold};
+    --typography-weight-bold: #{$font-weight-bold};
+
+    // Line height
+    --typography-line-height-tight: #{$line-height-tight};
+    --typography-line-height-snug: #{$line-height-snug};
+    --typography-line-height-normal: #{$line-height-normal};
+    --typography-line-height-relaxed: #{$line-height-relaxed};
+}

--- a/packages/sigil/src/tokens/_color.scss
+++ b/packages/sigil/src/tokens/_color.scss
@@ -1,0 +1,26 @@
+@use '../primitives/color' as *;
+
+// Surface
+$color-surface-subtle: var(--color-surface-subtle, #{$color-maroon-100});
+$color-surface-default: var(--color-surface-default, #{$color-maroon-50});
+$color-surface-raised: var(--color-surface-raised, #{$color-white});
+$color-surface-overlay: var(--color-surface-overlay, #{$color-white});
+
+// Text
+$color-text-primary: var(--color-text-primary, #{$color-grey-900});
+$color-text-secondary: var(--color-text-secondary, #{$color-grey-600});
+$color-text-disabled: var(--color-text-disabled, #{$color-grey-400});
+$color-text-inverse: var(--color-text-inverse, #{$color-white});
+$color-text-on-interactive: var(--color-text-on-interactive, #{$color-white});
+
+// Border
+$color-border-subtle: var(--color-border-subtle, #{$color-grey-100});
+$color-border-default: var(--color-border-default, #{$color-grey-200});
+$color-border-strong: var(--color-border-strong, #{$color-grey-400});
+
+// Interactive
+$color-interactive-primary: var(--color-interactive-primary, #{$color-maroon-600});
+$color-interactive-primary-hover: var(--color-interactive-primary-hover, #{$color-maroon-700});
+$color-interactive-primary-active: var(--color-interactive-primary-active, #{$color-maroon-800});
+$color-interactive-danger: var(--color-interactive-danger, #{$color-red-600});
+$color-interactive-focus: var(--color-interactive-focus, #{$color-maroon-400});

--- a/packages/sigil/src/tokens/_typography.scss
+++ b/packages/sigil/src/tokens/_typography.scss
@@ -1,0 +1,25 @@
+@use '../primitives/font-size' as *;
+@use '../primitives/font-weight' as *;
+@use '../primitives/line-height' as *;
+
+// Size
+$typography-size-xs: var(--typography-size-xs, #{$font-size-xs});
+$typography-size-sm: var(--typography-size-sm, #{$font-size-sm});
+$typography-size-md: var(--typography-size-md, #{$font-size-md});
+$typography-size-lg: var(--typography-size-lg, #{$font-size-lg});
+$typography-size-xl: var(--typography-size-xl, #{$font-size-xl});
+$typography-size-2xl: var(--typography-size-2xl, #{$font-size-2xl});
+$typography-size-3xl: var(--typography-size-3xl, #{$font-size-3xl});
+$typography-size-4xl: var(--typography-size-4xl, #{$font-size-4xl});
+
+// Weight
+$typography-weight-regular: var(--typography-weight-regular, #{$font-weight-regular});
+$typography-weight-medium: var(--typography-weight-medium, #{$font-weight-medium});
+$typography-weight-semibold: var(--typography-weight-semibold, #{$font-weight-semibold});
+$typography-weight-bold: var(--typography-weight-bold, #{$font-weight-bold});
+
+// Line height
+$typography-line-height-tight: var(--typography-line-height-tight, #{$line-height-tight});
+$typography-line-height-snug: var(--typography-line-height-snug, #{$line-height-snug});
+$typography-line-height-normal: var(--typography-line-height-normal, #{$line-height-normal});
+$typography-line-height-relaxed: var(--typography-line-height-relaxed, #{$line-height-relaxed});


### PR DESCRIPTION
## Summary

### Context

Sigil already has a primitive token layer — colors, font sizes, spacing, and radius defined as SCSS variables. This PR maps those primitives to semantic CSS custom properties on `:root`, giving consuming apps a stable, role-based token API for colors and typography as required by issue #25.

### Changes

Extended the primitive layer with `$color-white` and `$color-black` (both using a warm hue offset at 32° for tonal consistency with surfaces), plus new `_font-weight.scss` and `_line-height.scss` partials. Added `src/semantics/` which compiles color and typography tokens to CSS custom properties on `:root`. Added `src/tokens/` — SCSS variables that compile to `var()` with a light-theme primitive fallback, keeping runtime theming intact while allowing ergonomic SCSS variable references in consumer stylesheets. Updated the post-build script to ship `primitives/` and `tokens/` SCSS in the dist output and strip the `scripts` field from the distributed package manifest. Added an `exports` field to `package.json` with a `sass` condition for `pkg:` URL resolution in toolchains that support `NodePackageImporter`. Documented all consumption patterns (global CSS, SCSS tokens, SCSS primitives) in the README.

## Test Plan

- [x] `moon run sigil:build` compiles without errors
- [x] `dist/packages/sigil/index.css` contains all expected `:root` custom properties for color and typography
- [x] `dist/packages/sigil/primitives/` contains all six SCSS partial files
- [x] `dist/packages/sigil/tokens/` contains `_color.scss` and `_typography.scss`
- [x] `dist/packages/sigil/package.json` has the `exports` field and no `scripts` field
- [x] A token SCSS variable (e.g. `$color-surface-raised`) compiles to `var(--color-surface-raised, oklch(99% 0.006 32deg))` in consumer output

Closes: #25