### PR TITLE
feat(sigil): Dark theme overrides and three-state theming

### DIFF
--- a/docs/adr/0010-warm-tinted-surface-tokens.md
+++ b/docs/adr/0010-warm-tinted-surface-tokens.md
@@ -1,28 +1,37 @@
-# ADR 0010: Warm-tinted surface tokens for the light theme
+# ADR 0010: Warm-tinted surface tokens for both themes
 
 - **Status:** Accepted
 - **Date:** 2026-06-01
 
 ## Context
 
-The semantic color layer needs a surface family for the light theme default — page backgrounds, wells, cards, and overlays. The obvious choice is the grey scale (`$color-grey-50`/`100`), which is chromatic neutral. The platform's primary brand color is maroon (hue 32°).
+The semantic color layer needs a surface family for both the light and dark themes — page backgrounds, wells, cards, and overlays. The obvious choice for a neutral surface is the gray scale, which is chromatically neutral. The platform's primary brand color is maroon (hue 32°).
 
 ## Decision
 
-Surface tokens use the **maroon primitive scale** rather than the grey scale:
+Surface tokens use the **maroon primitive scale** across both themes rather than the gray scale.
+
+**Light theme** uses the bright end of the scale:
 
 - `--color-surface-subtle` → `$color-maroon-100` (93% lightness)
 - `--color-surface-default` → `$color-maroon-50` (97% lightness)
 - `--color-surface-raised` / `--color-surface-overlay` → `$color-white` (99% lightness, hue 32°)
 
-The difference from pure grey is subtle — `$color-maroon-50` is `oklch(97% 0.01 32deg)` versus `$color-grey-50` at `oklch(97% 0.004 0deg)` — but it gives light mode a faint parchment warmth that fits the platform's D&D identity.
+**Dark theme** uses the dark end, stepping upward as elements elevate:
+
+- `--color-surface-subtle` → `$color-maroon-950` (13% lightness)
+- `--color-surface-default` → `$color-maroon-900` (19% lightness)
+- `--color-surface-raised` → `$color-maroon-800` (26% lightness)
+- `--color-surface-overlay` → `$color-maroon-700` (33% lightness)
+
+The difference from pure gray is subtle in light mode — `$color-maroon-50` is `oklch(97% 0.01 32deg)` versus `$color-grey-50` at `oklch(97% 0.004 0deg)` — but gives light mode a faint parchment warmth that fits the platform's D&D identity. In dark mode, the warm tint is similarly subtle but maintains hue continuity across the full lightness range.
 
 For tonal consistency, the white and black primitives also carry hue 32°: `$color-white: oklch(99% 0.006 32deg)` and `$color-black: oklch(8% 0.006 32deg)`.
 
-The grey scale is reserved for text and border tokens, where chromatic neutrality reads more cleanly against warm surfaces.
+The gray scale is reserved for text and border tokens, where chromatic neutrality reads more cleanly against warm surfaces.
 
 ## Consequences
 
-- Light mode has a cohesive warmth throughout — surface, raised, and overlay layers all share the same hue family.
-- Grey text on a maroon-tinted surface produces a subtle but intentional contrast in hue, avoiding the flat look of grey-on-grey.
-- Dark theme overrides (ADR pending, issue #26) will need to decide independently whether dark surfaces follow the same hue or shift to a cooler neutral.
+- Both light and dark modes share a cohesive warmth — all surface layers use the same hue family across the full lightness range.
+- Gray text and borders on a maroon-tinted surface produce a subtle but intentional hue contrast, avoiding the flat look of gray-on-gray in both modes.
+- The four dark surface steps (`950` → `700`) mirror the light steps (`100` → `white`) in elevation semantics: subtle is the deepest background, overlay is the highest.

--- a/docs/adr/0012-dark-first-root-baseline.md
+++ b/docs/adr/0012-dark-first-root-baseline.md
@@ -1,0 +1,37 @@
+# ADR 0012: Dark-first `:root` baseline for the three-state theme model
+
+- **Status:** Accepted
+- **Date:** 2026-06-01
+
+## Context
+
+The platform has three theme states: `dark` (platform default), `light`, and `system` (follows `prefers-color-scheme`). `ThemeService` in Arcane UI defaults to `dark` — it writes `[data-theme="dark"]` on `<html>` on first load unless the user has stored a preference.
+
+The conventional CSS pattern puts light values on `:root` and overrides with `@media (prefers-color-scheme: dark)`. Under that model, any user who sees the page before `ThemeService` initialises (initial paint, SSR, JS failure) gets a light flash before the dark theme is applied.
+
+## Decision
+
+`:root` holds the **dark theme values**. The media query direction is inverted: `@media (prefers-color-scheme: light)` applies light overrides for system mode. `[data-theme]` attribute selectors re-assert explicit user preference, winning by specificity over the media query.
+
+The full selector stack:
+
+| Condition              | Selector that governs                            |
+|:-----------------------|:-------------------------------------------------|
+| No attribute, OS dark  | `:root` (dark default)                           |
+| No attribute, OS light | `@media (prefers-color-scheme: light) { :root }` |
+| Explicit dark          | `[data-theme="dark"]`                            |
+| Explicit light         | `[data-theme="light"]`                           |
+
+A SCSS mixin is used to avoid duplicating dark values between `:root` and `[data-theme="dark"]`, and light values between the media query and `[data-theme="light"]`.
+
+## Considered alternatives
+
+**Light `:root` baseline (conventional)** — `:root` holds light values, `@media (prefers-color-scheme: dark)` applies dark overrides. This is the near-universal convention and what was initially implemented in #25. Rejected because it produces a light flash on first paint for the majority of users, since the platform default is dark.
+
+## Consequences
+
+- Pre-JS and SSR renders are dark, matching the intended default experience with no flash.
+- The inverted media query direction (`prefers-color-scheme: light` instead of `dark`) is non-clear to readers unfamiliar with the platform's dark-first intent — hence this ADR.
+- `[data-theme="dark"]` is still required: it overrides `@media (prefers-color-scheme: light)` for users who explicitly picked dark while their OS is set to light.
+- Dark interactive elements use a lighten-on-hover model (rest `maroon-400` → hover `maroon-300` → active `maroon-500`) rather than the darken-on-hover used in light mode — hover brightens for better state legibility on dark surfaces.
+- The focus ring token is split into two: `--color-interactive-focus-on-primary` (gold, for maroon elements) and `--color-interactive-focus-on-secondary` (maroon, for gold elements). This ensures the focus ring is always a contrasting hue to the element it encircles.

--- a/packages/sigil/src/semantics/_color.scss
+++ b/packages/sigil/src/semantics/_color.scss
@@ -1,6 +1,34 @@
 @use '../primitives/color' as *;
 
-:root {
+@mixin dark-theme-colors() {
+    // Surface
+    --color-surface-subtle: #{$color-maroon-950};
+    --color-surface-default: #{$color-maroon-900};
+    --color-surface-raised: #{$color-maroon-800};
+    --color-surface-overlay: #{$color-maroon-700};
+
+    // Text
+    --color-text-primary: #{$color-white};
+    --color-text-secondary: #{$color-grey-300};
+    --color-text-disabled: #{$color-grey-600};
+    --color-text-inverse: #{$color-grey-900};
+    --color-text-on-interactive: #{$color-grey-900};
+
+    // Border
+    --color-border-subtle: #{$color-grey-800};
+    --color-border-default: #{$color-grey-700};
+    --color-border-strong: #{$color-grey-500};
+
+    // Interactive
+    --color-interactive-primary: #{$color-maroon-400};
+    --color-interactive-primary-hover: #{$color-maroon-300};
+    --color-interactive-primary-active: #{$color-maroon-500};
+    --color-interactive-danger: #{$color-red-400};
+    --color-interactive-focus-on-primary: #{$color-gold-400};
+    --color-interactive-focus-on-secondary: #{$color-maroon-300};
+}
+
+@mixin light-theme-colors() {
     // Surface
     --color-surface-subtle: #{$color-maroon-100};
     --color-surface-default: #{$color-maroon-50};
@@ -24,5 +52,24 @@
     --color-interactive-primary-hover: #{$color-maroon-700};
     --color-interactive-primary-active: #{$color-maroon-800};
     --color-interactive-danger: #{$color-red-600};
-    --color-interactive-focus: #{$color-maroon-400};
+    --color-interactive-focus-on-primary: #{$color-gold-500};
+    --color-interactive-focus-on-secondary: #{$color-maroon-400};
+}
+
+:root {
+    @include dark-theme-colors;
+}
+
+@media (prefers-color-scheme: light) {
+    :root {
+        @include light-theme-colors;
+    }
+}
+
+[data-theme='light'] {
+    @include light-theme-colors;
+}
+
+[data-theme='dark'] {
+    @include dark-theme-colors;
 }

--- a/packages/sigil/src/tokens/_color.scss
+++ b/packages/sigil/src/tokens/_color.scss
@@ -1,26 +1,27 @@
 @use '../primitives/color' as *;
 
 // Surface
-$color-surface-subtle: var(--color-surface-subtle, #{$color-maroon-100});
-$color-surface-default: var(--color-surface-default, #{$color-maroon-50});
-$color-surface-raised: var(--color-surface-raised, #{$color-white});
-$color-surface-overlay: var(--color-surface-overlay, #{$color-white});
+$color-surface-subtle: var(--color-surface-subtle, #{$color-maroon-950});
+$color-surface-default: var(--color-surface-default, #{$color-maroon-900});
+$color-surface-raised: var(--color-surface-raised, #{$color-maroon-800});
+$color-surface-overlay: var(--color-surface-overlay, #{$color-maroon-700});
 
 // Text
-$color-text-primary: var(--color-text-primary, #{$color-grey-900});
-$color-text-secondary: var(--color-text-secondary, #{$color-grey-600});
-$color-text-disabled: var(--color-text-disabled, #{$color-grey-400});
-$color-text-inverse: var(--color-text-inverse, #{$color-white});
-$color-text-on-interactive: var(--color-text-on-interactive, #{$color-white});
+$color-text-primary: var(--color-text-primary, #{$color-white});
+$color-text-secondary: var(--color-text-secondary, #{$color-grey-300});
+$color-text-disabled: var(--color-text-disabled, #{$color-grey-600});
+$color-text-inverse: var(--color-text-inverse, #{$color-grey-900});
+$color-text-on-interactive: var(--color-text-on-interactive, #{$color-grey-900});
 
 // Border
-$color-border-subtle: var(--color-border-subtle, #{$color-grey-100});
-$color-border-default: var(--color-border-default, #{$color-grey-200});
-$color-border-strong: var(--color-border-strong, #{$color-grey-400});
+$color-border-subtle: var(--color-border-subtle, #{$color-grey-800});
+$color-border-default: var(--color-border-default, #{$color-grey-700});
+$color-border-strong: var(--color-border-strong, #{$color-grey-500});
 
 // Interactive
-$color-interactive-primary: var(--color-interactive-primary, #{$color-maroon-600});
-$color-interactive-primary-hover: var(--color-interactive-primary-hover, #{$color-maroon-700});
-$color-interactive-primary-active: var(--color-interactive-primary-active, #{$color-maroon-800});
-$color-interactive-danger: var(--color-interactive-danger, #{$color-red-600});
-$color-interactive-focus: var(--color-interactive-focus, #{$color-maroon-400});
+$color-interactive-primary: var(--color-interactive-primary, #{$color-maroon-400});
+$color-interactive-primary-hover: var(--color-interactive-primary-hover, #{$color-maroon-300});
+$color-interactive-primary-active: var(--color-interactive-primary-active, #{$color-maroon-500});
+$color-interactive-danger: var(--color-interactive-danger, #{$color-red-400});
+$color-interactive-focus-on-primary: var(--color-interactive-focus-on-primary, #{$color-gold-400});
+$color-interactive-focus-on-secondary: var(--color-interactive-focus-on-secondary, #{$color-maroon-300});


### PR DESCRIPTION
### Context

Sigil's semantic color layer previously defined only light theme tokens on `:root`. Issue #26 calls for dark theme overrides via `[data-theme]` and `prefers-color-scheme`, plus an explicit light override for user-controlled theming.

### Changes

- Restructured `semantics/_color.scss` with `dark-theme-colors()` and `light-theme-colors()` SCSS mixins to avoid duplication across the `[data-theme]` selectors and media query block.
- `:root` now defaults to dark theme values; `@media (prefers-color-scheme: light)` handles system-light mode, inverting the conventional approach to avoid a light flash before `ThemeService` initialises.
- Dark surfaces follow the same warm maroon hue as light mode, using the dark end of the scale (`maroon-950` → `maroon-700`) rather than shifting to a cool neutral.
- `--color-interactive-focus` split into `--color-interactive-focus-on-primary` (gold ring, for maroon elements) and `--color-interactive-focus-on-secondary` (maroon ring, for gold elements).
- Dark interactive states use a lighten-on-hover model (`maroon-400` rest → `maroon-300` hover → `maroon-500` active).
- Token fallbacks in `tokens/_color.scss` updated to match the new dark defaults.
- ADR 0010 extended to cover dark surface token decisions; ADR 0012 added to document the dark-first `:root` baseline.

## Test Plan

- [x] `pnpm --filter @dnd-mapp/sigil build` succeeds and produces valid CSS
- [x] `:root` block in compiled CSS contains dark surface values (`oklch(13% ...)` for `--color-surface-subtle`)
- [x] `[data-theme=light]` and `@media (prefers-color-scheme: light)` blocks contain light values
- [x] `[data-theme=dark]` block contains dark values
- [x] `--color-interactive-focus-on-primary` and `--color-interactive-focus-on-secondary` are present; `--color-interactive-focus` is gone

Closes: #26