### PR TITLE
build(tsconfig): Add arcane-ui path aliases

### DIFF
--- a/apps/realm/tsconfig.json
+++ b/apps/realm/tsconfig.json
@@ -10,7 +10,14 @@
         "outDir": "./dist/out-tsc",
         "paths": {
             "@/core/*": ["./src/core/*"],
-            "@/core/test/*": ["./test/core/*"]
+            "@/core/test/*": ["./test/core/*"],
+            "@dnd-mapp/arcane-ui": ["../../packages/arcane-ui/src/public-api.ts"],
+            "@dnd-mapp/arcane-ui/components": ["../../packages/arcane-ui/components/public-api.ts"],
+            "@dnd-mapp/arcane-ui/config": ["../../packages/arcane-ui/config/public-api.ts"],
+            "@dnd-mapp/arcane-ui/http": ["../../packages/arcane-ui/http/public-api.ts"],
+            "@dnd-mapp/arcane-ui/storage": ["../../packages/arcane-ui/storage/public-api.ts"],
+            "@dnd-mapp/arcane-ui/testing": ["../../packages/arcane-ui/testing/public-api.ts"],
+            "@dnd-mapp/arcane-ui/theming": ["../../packages/arcane-ui/theming/public-api.ts"]
         },
         "target": "es2024",
         "useDefineForClassFields": false

--- a/packages/arcane-ui/tsconfig.lib.json
+++ b/packages/arcane-ui/tsconfig.lib.json
@@ -4,7 +4,8 @@
     "exclude": ["**/*.spec.ts"],
     "compilerOptions": {
         "composite": true,
-        "outDir": "../../out-tsc/lib",
+        "tsBuildInfoFile": "./out-tsc/lib/.tsbuildinfo",
+        "outDir": "./out-tsc/lib",
         "declaration": true,
         "declarationMap": true,
         "types": []

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,5 +1,14 @@
 {
     "compilerOptions": {
+        "paths": {
+            "@dnd-mapp/arcane-ui": ["./packages/arcane-ui/src/public-api.ts"],
+            "@dnd-mapp/arcane-ui/components": ["./packages/arcane-ui/components/public-api.ts"],
+            "@dnd-mapp/arcane-ui/config": ["./packages/arcane-ui/config/public-api.ts"],
+            "@dnd-mapp/arcane-ui/http": ["./packages/arcane-ui/http/public-api.ts"],
+            "@dnd-mapp/arcane-ui/storage": ["./packages/arcane-ui/storage/public-api.ts"],
+            "@dnd-mapp/arcane-ui/testing": ["./packages/arcane-ui/testing/public-api.ts"],
+            "@dnd-mapp/arcane-ui/theming": ["./packages/arcane-ui/theming/public-api.ts"]
+        },
         "allowUnreachableCode": false,
         "allowUnusedLabels": false,
         "exactOptionalPropertyTypes": true,


### PR DESCRIPTION
## Summary

### Context

Without path aliases for `@dnd-mapp/arcane-ui`, the Angular CLI and TypeScript language server cannot resolve imports to the package's source files — a built artifact must exist first. This forces a build step before any code that imports from the library can be developed, which slows the inner loop.

### Changes

Adds `paths` entries for `@dnd-mapp/arcane-ui` and its six secondary entry points (`/components`, `/config`, `/http`, `/storage`, `/testing`, `/theming`) to `tsconfig.base.json`, mapping each alias to its `public-api.ts` source file. Any project that extends `tsconfig.base.json` without overriding `paths` inherits these aliases automatically.

Because TypeScript replaces (rather than merges) `paths` when one config extends another, the same aliases are also added to `apps/realm/tsconfig.json` alongside its existing `@/core/*` entries — without this, Realm's own path overrides would silently shadow all of the base config's aliases.

Also aligns `packages/arcane-ui/tsconfig.lib.json` with the build output conventions from the recent workspace refactor: the `outDir` is now package-relative (`./out-tsc/lib`) and `tsBuildInfoFile` is set explicitly.

## Test Plan

- [x] Run `npx tsc -p apps/realm/tsconfig.app.json --noEmit` — should complete without errors
- [x] Add a test import of `@dnd-mapp/arcane-ui` in a Realm source file and confirm the language server resolves it to the source without a prior build

Closes: #83