### PR TITLE
Implement StorageService with injectable storage token

### DIFF
--- a/packages/arcane-ui/angular.json
+++ b/packages/arcane-ui/angular.json
@@ -1,6 +1,9 @@
 {
     "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
     "version": 1,
+    "cli": {
+        "analytics": "4e82e6d1-6158-404d-a1ac-f6cc21212704"
+    },
     "schematics": {
         "@schematics/angular:component": {
             "style": "scss",
@@ -11,7 +14,7 @@
         "arcane-ui": {
             "projectType": "library",
             "root": ".",
-            "sourceRoot": "./src",
+            "sourceRoot": ".",
             "prefix": "dma",
             "architect": {
                 "build": {
@@ -73,8 +76,5 @@
                 }
             }
         }
-    },
-    "cli": {
-        "analytics": "4e82e6d1-6158-404d-a1ac-f6cc21212704"
     }
 }

--- a/packages/arcane-ui/common/lib/provide-storage.ts
+++ b/packages/arcane-ui/common/lib/provide-storage.ts
@@ -1,7 +1,32 @@
 import { InjectionToken, type Provider } from '@angular/core';
 
+/**
+ * Injection token for the active {@link Storage} implementation.
+ *
+ * Provide a value with {@link provideStorage}.
+ */
 export const STORAGE = new InjectionToken<Storage>('STORAGE');
 
+/**
+ * Configures the {@link Storage} implementation injected by {@link StorageService}.
+ *
+ * Can be used at application level in `bootstrapApplication` or overridden at
+ * component level via the component's `providers` array.
+ *
+ * @param storage - The `Storage` instance to use (e.g. `localStorage`, `sessionStorage`,
+ *   or a `MockStorage` in tests).
+ *
+ * @example
+ * // Application level
+ * bootstrapApplication(AppComponent, {
+ *   providers: [provideStorage(localStorage)],
+ * });
+ *
+ * @example
+ * // Component level override
+ * @Component({ providers: [provideStorage(sessionStorage)] })
+ * export class MyComponent {}
+ */
 export function provideStorage(storage: Storage): Provider[] {
     return [{ provide: STORAGE, useValue: storage }];
 }

--- a/packages/arcane-ui/common/lib/provide-storage.ts
+++ b/packages/arcane-ui/common/lib/provide-storage.ts
@@ -1,0 +1,7 @@
+import { InjectionToken, type Provider } from '@angular/core';
+
+export const STORAGE = new InjectionToken<Storage>('STORAGE');
+
+export function provideStorage(storage: Storage): Provider[] {
+    return [{ provide: STORAGE, useValue: storage }];
+}

--- a/packages/arcane-ui/common/ng-package.json
+++ b/packages/arcane-ui/common/ng-package.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "../node_modules/ng-packagr/ng-package.schema.json",
+    "lib": {
+        "entryFile": "public-api.ts"
+    }
+}

--- a/packages/arcane-ui/common/public-api.ts
+++ b/packages/arcane-ui/common/public-api.ts
@@ -1,0 +1,1 @@
+export { STORAGE, provideStorage } from './lib/provide-storage';

--- a/packages/arcane-ui/package.json
+++ b/packages/arcane-ui/package.json
@@ -11,11 +11,11 @@
   },
   "scripts": {
     "build": "ng run arcane-ui:build",
-    "build-dev": "ng run arcane-ui:build -c dev",
+    "build-dev": "ng run arcane-ui:build:dev",
     "storybook-start": "ng run arcane-ui:storybook-start",
     "storybook-build": "ng run arcane-ui:storybook-build",
     "test-ci": "ng run arcane-ui:test",
-    "test": "ng run arcane-ui:test -c dev",
+    "test": "ng run arcane-ui:test:dev",
     "lint-ts": "ng run arcane-ui:lint",
     "lint-css": "stylelint \"**/*.scss\""
   },

--- a/packages/arcane-ui/src/lib/dummy.spec.ts
+++ b/packages/arcane-ui/src/lib/dummy.spec.ts
@@ -1,5 +1,0 @@
-describe('Dummy', () => {
-    it('should test', () => {
-        expect(true).toEqual(true);
-    });
-});

--- a/packages/arcane-ui/storage/lib/storage.service.spec.ts
+++ b/packages/arcane-ui/storage/lib/storage.service.spec.ts
@@ -1,0 +1,61 @@
+import { TestBed } from '@angular/core/testing';
+import { provideStorage, STORAGE } from '@dnd-mapp/arcane-ui/common';
+import { MockStorage } from '@dnd-mapp/arcane-ui/storage/testing';
+import { setupTestEnvironment } from '@dnd-mapp/arcane-ui/testing';
+import { StorageService } from './storage.service';
+
+describe('StorageService', () => {
+    function setupTest() {
+        setupTestEnvironment({
+            providers: [StorageService, provideStorage(new MockStorage())],
+        });
+
+        return {
+            service: TestBed.inject(StorageService),
+            mockStorage: TestBed.inject(STORAGE),
+        };
+    }
+
+    it('returns null for a missing key', () => {
+        const { service } = setupTest();
+
+        expect(service.get('missing')).toBeNull();
+    });
+
+    it('round-trips a primitive value', () => {
+        const { service } = setupTest();
+
+        service.set('num', 42);
+        expect(service.get('num')).toBe(42);
+    });
+
+    it('round-trips an object value', () => {
+        const { service } = setupTest();
+
+        service.set('obj', { a: 1, b: 'two' });
+        expect(service.get('obj')).toEqual({ a: 1, b: 'two' });
+    });
+
+    it('removes a key', () => {
+        const { service } = setupTest();
+
+        service.set('key', 'value');
+        service.remove('key');
+        expect(service.get('key')).toBeNull();
+    });
+
+    it('overwriting a key reflects the new value', () => {
+        const { service } = setupTest();
+
+        service.set('key', 'first');
+        service.set('key', 'second');
+        expect(service.get('key')).toBe('second');
+    });
+
+    it('returns null when the stored value is not valid JSON', () => {
+        const { service, mockStorage } = setupTest();
+
+        mockStorage.setItem('key', 'not valid json {');
+        expect(service.get('key')).toBeNull();
+    });
+});

--- a/packages/arcane-ui/storage/lib/storage.service.ts
+++ b/packages/arcane-ui/storage/lib/storage.service.ts
@@ -1,0 +1,27 @@
+import { inject, Injectable } from '@angular/core';
+import { STORAGE } from '@dnd-mapp/arcane-ui/common';
+
+@Injectable({ providedIn: null })
+export class StorageService {
+    private readonly storage = inject(STORAGE);
+
+    public get<T>(key: string): T | null {
+        const raw = this.storage.getItem(key);
+
+        if (raw === null) return null;
+
+        try {
+            return JSON.parse(raw) as T;
+        } catch {
+            return null;
+        }
+    }
+
+    public set<T>(key: string, value: T): void {
+        this.storage.setItem(key, JSON.stringify(value));
+    }
+
+    public remove(key: string): void {
+        this.storage.removeItem(key);
+    }
+}

--- a/packages/arcane-ui/storage/lib/storage.service.ts
+++ b/packages/arcane-ui/storage/lib/storage.service.ts
@@ -1,10 +1,27 @@
 import { inject, Injectable } from '@angular/core';
 import { STORAGE } from '@dnd-mapp/arcane-ui/common';
 
+/**
+ * Typed wrapper around a {@link Storage} implementation (e.g. `localStorage` or `sessionStorage`).
+ *
+ * Values are JSON-serialized on write and deserialized on read. Must be provided
+ * explicitly via {@link provideStorage} — there is no default storage backend.
+ *
+ * @example
+ * bootstrapApplication(AppComponent, {
+ *   providers: [provideStorage(localStorage), StorageService],
+ * });
+ */
 @Injectable({ providedIn: null })
 export class StorageService {
     private readonly storage = inject(STORAGE);
 
+    /**
+     * Retrieves and deserializes the value stored under `key`.
+     *
+     * @returns The parsed value, or `null` if the key does not exist or its
+     *   value is not valid JSON.
+     */
     public get<T>(key: string): T | null {
         const raw = this.storage.getItem(key);
 
@@ -17,10 +34,15 @@ export class StorageService {
         }
     }
 
+    /**
+     * Serializes `value` as JSON and stores it under `key`, overwriting any
+     * existing entry.
+     */
     public set<T>(key: string, value: T): void {
         this.storage.setItem(key, JSON.stringify(value));
     }
 
+    /** Removes the entry for `key`. No-op if the key does not exist. */
     public remove(key: string): void {
         this.storage.removeItem(key);
     }

--- a/packages/arcane-ui/storage/public-api.ts
+++ b/packages/arcane-ui/storage/public-api.ts
@@ -1,1 +1,1 @@
-export {};
+export { StorageService } from './lib/storage.service';

--- a/packages/arcane-ui/storage/testing/lib/mock-storage.ts
+++ b/packages/arcane-ui/storage/testing/lib/mock-storage.ts
@@ -1,0 +1,27 @@
+export class MockStorage implements Storage {
+    private store: Record<string, string> = {};
+
+    public get length(): number {
+        return Object.keys(this.store).length;
+    }
+
+    public clear(): void {
+        this.store = {};
+    }
+
+    public getItem(key: string): string | null {
+        return this.store[key] ?? null;
+    }
+
+    public key(index: number): string | null {
+        return Object.keys(this.store)[index] ?? null;
+    }
+
+    public removeItem(key: string): void {
+        delete this.store[key];
+    }
+
+    public setItem(key: string, value: string): void {
+        this.store[key] = value;
+    }
+}

--- a/packages/arcane-ui/storage/testing/lib/mock-storage.ts
+++ b/packages/arcane-ui/storage/testing/lib/mock-storage.ts
@@ -1,3 +1,13 @@
+/**
+ * In-memory implementation of the {@link Storage} interface for use in unit tests.
+ *
+ * Pass an instance to {@link provideStorage} to isolate tests from the real browser storage.
+ *
+ * @example
+ * TestBed.configureTestingModule({
+ *   providers: [StorageService, provideStorage(new MockStorage())],
+ * });
+ */
 export class MockStorage implements Storage {
     private store: Record<string, string> = {};
 

--- a/packages/arcane-ui/storage/testing/ng-package.json
+++ b/packages/arcane-ui/storage/testing/ng-package.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
+    "lib": {
+        "entryFile": "public-api.ts"
+    }
+}

--- a/packages/arcane-ui/storage/testing/public-api.ts
+++ b/packages/arcane-ui/storage/testing/public-api.ts
@@ -1,0 +1,1 @@
+export { MockStorage } from './lib/mock-storage';

--- a/packages/arcane-ui/testing/public-api.ts
+++ b/packages/arcane-ui/testing/public-api.ts
@@ -1,1 +1,1 @@
-export {};
+export { setupTestEnvironment } from './utils/setup-test-environment';

--- a/packages/arcane-ui/testing/utils/setup-test-environment.ts
+++ b/packages/arcane-ui/testing/utils/setup-test-environment.ts
@@ -13,7 +13,6 @@ export interface SetupTestEnvironmentParams {
  */
 export function setupTestEnvironment(params: SetupTestEnvironmentParams = {}) {
     TestBed.configureTestingModule({
-        imports: [],
         providers: [...(params?.providers ?? [])],
     });
 

--- a/packages/arcane-ui/testing/utils/setup-test-environment.ts
+++ b/packages/arcane-ui/testing/utils/setup-test-environment.ts
@@ -1,9 +1,16 @@
 import { TestBed } from '@angular/core/testing';
 
+/** Parameters accepted by {@link setupTestEnvironment}. */
 export interface SetupTestEnvironmentParams {
     providers?: unknown[];
 }
 
+/**
+ * Configures a `TestBed` environment for a single test or `describe` block.
+ *
+ * @param params - Optional configuration. Pass `providers` to register services,
+ *   tokens, or other providers for the test.
+ */
 export function setupTestEnvironment(params: SetupTestEnvironmentParams = {}) {
     TestBed.configureTestingModule({
         imports: [],

--- a/packages/arcane-ui/testing/utils/setup-test-environment.ts
+++ b/packages/arcane-ui/testing/utils/setup-test-environment.ts
@@ -1,0 +1,14 @@
+import { TestBed } from '@angular/core/testing';
+
+export interface SetupTestEnvironmentParams {
+    providers?: unknown[];
+}
+
+export function setupTestEnvironment(params: SetupTestEnvironmentParams = {}) {
+    TestBed.configureTestingModule({
+        imports: [],
+        providers: [...(params?.providers ?? [])],
+    });
+
+    return {};
+}

--- a/packages/arcane-ui/tsconfig.lib.json
+++ b/packages/arcane-ui/tsconfig.lib.json
@@ -1,14 +1,6 @@
 {
     "extends": "./tsconfig.json",
-    "include": [
-        "components/**/*.ts",
-        "config/**/*.ts",
-        "http/**/*.ts",
-        "src/**/*.ts",
-        "storage/**/*.ts",
-        "testing/**/*.ts",
-        "theming/**/*.ts"
-    ],
+    "include": ["**/*.ts"],
     "exclude": ["**/*.spec.ts", "**/*.stories.ts"],
     "compilerOptions": {
         "composite": true,

--- a/packages/arcane-ui/vitest.config.mts
+++ b/packages/arcane-ui/vitest.config.mts
@@ -18,7 +18,7 @@ export default defineConfig({
         clearMocks: true,
         coverage: {
             enabled: true,
-            exclude: ['main.ts', '**/config/*.ts', '**/test/**/*'],
+            exclude: ['main.ts', '**/config/*.ts', '**/test/**/*', '**/testing/**'],
             provider: 'v8',
             reporter: ['text-summary', 'html', 'cobertura'],
             reportOnFailure: true,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -17,10 +17,12 @@
         "noUnusedParameters": true,
         "paths": {
             "@dnd-mapp/arcane-ui": ["./packages/arcane-ui/src/public-api.ts"],
+            "@dnd-mapp/arcane-ui/common": ["./packages/arcane-ui/common/public-api.ts"],
             "@dnd-mapp/arcane-ui/components": ["./packages/arcane-ui/components/public-api.ts"],
             "@dnd-mapp/arcane-ui/config": ["./packages/arcane-ui/config/public-api.ts"],
             "@dnd-mapp/arcane-ui/http": ["./packages/arcane-ui/http/public-api.ts"],
             "@dnd-mapp/arcane-ui/storage": ["./packages/arcane-ui/storage/public-api.ts"],
+            "@dnd-mapp/arcane-ui/storage/testing": ["./packages/arcane-ui/storage/testing/public-api.ts"],
             "@dnd-mapp/arcane-ui/testing": ["./packages/arcane-ui/testing/public-api.ts"],
             "@dnd-mapp/arcane-ui/theming": ["./packages/arcane-ui/theming/public-api.ts"]
         },


### PR DESCRIPTION
## Summary

### Context

The `@dnd-mapp/arcane-ui` library needed a typed, testable abstraction over browser storage. Directly referencing `window.localStorage` or `window.sessionStorage` in application code couples components to the browser environment and makes unit testing cumbersome.

### Changes

Added a `StorageService` to the `storage` entry point that wraps any `Storage` implementation behind typed `get<T>`, `set<T>`, and `remove` methods, returning `null` for missing keys or unparseable JSON. The service is decoupled from any concrete storage via a `STORAGE` injection token exported from a new `common` entry point alongside a `provideStorage()` factory, making it straightforward to swap in `localStorage`, `sessionStorage`, or a test double at application or component level. A new `storage/testing` entry point provides an in-memory `MockStorage` for use in specs. Two supporting fixes also land in this branch: the Angular `sourceRoot` and `tsconfig.lib.json` settings were corrected so the unit-test builder discovers specs in secondary entry points, and the placeholder dummy spec and incorrect `ng run` script syntax were cleaned up.

## Test Plan

- [x] Run `ng run arcane-ui:test` — 6 specs pass with 100% coverage
- [x] Run `ng run arcane-ui:build` — `common`, `storage`, and `storage/testing` entry points all build successfully
- [x] In an application, provide `[provideStorage(localStorage), StorageService]` and verify `StorageService` reads and writes `localStorage`
- [x] In a unit test, provide `[provideStorage(new MockStorage()), StorageService]` and verify values are isolated to the in-memory store

Closes: #44