### PR TITLE
Implement RequestService with typed HTTP methods

### DIFF
--- a/packages/arcane-ui/config/lib/config.service.spec.ts
+++ b/packages/arcane-ui/config/lib/config.service.spec.ts
@@ -1,5 +1,7 @@
+import { provideHttpClient } from '@angular/common/http';
 import { TestBed } from '@angular/core/testing';
 import { CONFIG_URL } from '@dnd-mapp/arcane-ui/common';
+import { RequestService } from '@dnd-mapp/arcane-ui/http';
 import { setupTestEnvironment } from '@dnd-mapp/arcane-ui/testing';
 import { http, HttpResponse } from 'msw';
 import { setupWorker } from 'msw/browser';
@@ -23,7 +25,12 @@ describe('ConfigService', () => {
 
     function setupTest() {
         setupTestEnvironment({
-            providers: [ConfigService, { provide: CONFIG_URL, useValue: '/test-config.json' }],
+            providers: [
+                ConfigService,
+                RequestService,
+                provideHttpClient(),
+                { provide: CONFIG_URL, useValue: '/test-config.json' },
+            ],
         });
 
         return { service: TestBed.inject(ConfigService<TestConfig>) };

--- a/packages/arcane-ui/config/lib/config.service.ts
+++ b/packages/arcane-ui/config/lib/config.service.ts
@@ -1,5 +1,7 @@
 import { inject, Injectable } from '@angular/core';
 import { CONFIG_URL } from '@dnd-mapp/arcane-ui/common';
+import { RequestService } from '@dnd-mapp/arcane-ui/http';
+import { firstValueFrom } from 'rxjs';
 
 /**
  * Fetches a JSON config file at bootstrap and exposes it as a typed singleton.
@@ -18,6 +20,7 @@ import { CONFIG_URL } from '@dnd-mapp/arcane-ui/common';
 @Injectable({ providedIn: null })
 export class ConfigService<T> {
     private readonly url = inject(CONFIG_URL);
+    private readonly requestService = inject(RequestService);
 
     private config!: T;
 
@@ -28,12 +31,6 @@ export class ConfigService<T> {
 
     /** Fetches and stores the config. Called automatically by {@link provideConfig}. */
     public async load(): Promise<void> {
-        // TODO - Use RequestService
-        const response = await fetch(this.url);
-
-        if (!response.ok) {
-            throw new Error(`Config fetch failed with status ${response.status}`);
-        }
-        this.config = (await response.json()) as T;
+        this.config = await firstValueFrom(this.requestService.get<T>(this.url));
     }
 }

--- a/packages/arcane-ui/config/lib/provide-config.ts
+++ b/packages/arcane-ui/config/lib/provide-config.ts
@@ -1,5 +1,6 @@
 import { inject, provideAppInitializer, type EnvironmentProviders, type Provider } from '@angular/core';
 import { CONFIG_URL } from '@dnd-mapp/arcane-ui/common';
+import { RequestService } from '@dnd-mapp/arcane-ui/http';
 import { ConfigService } from './config.service';
 
 /**
@@ -17,6 +18,7 @@ export function provideConfig<T>(url: string): (Provider | EnvironmentProviders)
     return [
         { provide: CONFIG_URL, useValue: url },
         ConfigService,
+        RequestService,
         provideAppInitializer(() => {
             const service = inject(ConfigService<T>);
 

--- a/packages/arcane-ui/http/lib/request.service.spec.ts
+++ b/packages/arcane-ui/http/lib/request.service.spec.ts
@@ -1,0 +1,105 @@
+import { provideHttpClient } from '@angular/common/http';
+import { TestBed } from '@angular/core/testing';
+import { setupTestEnvironment } from '@dnd-mapp/arcane-ui/testing';
+import { http, HttpResponse } from 'msw';
+import { setupWorker } from 'msw/browser';
+import { firstValueFrom } from 'rxjs';
+import { RequestService } from './request.service';
+
+interface TestPayload {
+    id: number;
+    name: string;
+}
+
+interface TestBody {
+    name: string;
+}
+
+describe('RequestService', () => {
+    const server = setupWorker();
+    const baseUrl = 'https://api.test';
+
+    beforeAll(async () => {
+        await server.start({ onUnhandledRequest: 'warn', quiet: true });
+    });
+
+    afterEach(() => {
+        server.resetHandlers();
+    });
+
+    function setupTest() {
+        setupTestEnvironment({
+            providers: [RequestService, provideHttpClient()],
+        });
+
+        return {
+            service: TestBed.inject(RequestService),
+        };
+    }
+
+    it('get returns the parsed response body', async () => {
+        const { service } = setupTest();
+        const payload: TestPayload = { id: 1, name: 'Alice' };
+
+        server.use(http.get(`${baseUrl}/items`, () => HttpResponse.json(payload)));
+
+        const result = await firstValueFrom(service.get<TestPayload>(`${baseUrl}/items`));
+
+        expect(result).toEqual(payload);
+    });
+
+    it('post sends the body and returns the response', async () => {
+        const { service } = setupTest();
+        const payload: TestPayload = { id: 2, name: 'Bob' };
+
+        server.use(http.post(`${baseUrl}/items`, () => HttpResponse.json(payload)));
+
+        const result = await firstValueFrom(service.post<TestPayload, TestBody>(`${baseUrl}/items`, { name: 'Bob' }));
+
+        expect(result).toEqual(payload);
+    });
+
+    it('put sends the body and returns the response', async () => {
+        const { service } = setupTest();
+        const payload: TestPayload = { id: 1, name: 'Updated' };
+
+        server.use(http.put(`${baseUrl}/items/1`, () => HttpResponse.json(payload)));
+
+        const result = await firstValueFrom(
+            service.put<TestPayload, TestBody>(`${baseUrl}/items/1`, { name: 'Updated' }),
+        );
+
+        expect(result).toEqual(payload);
+    });
+
+    it('patch sends the body and returns the response', async () => {
+        const { service } = setupTest();
+        const payload: TestPayload = { id: 1, name: 'Patched' };
+
+        server.use(http.patch(`${baseUrl}/items/1`, () => HttpResponse.json(payload)));
+
+        const result = await firstValueFrom(
+            service.patch<TestPayload, TestBody>(`${baseUrl}/items/1`, { name: 'Patched' }),
+        );
+
+        expect(result).toEqual(payload);
+    });
+
+    it('delete hits the correct url and returns the response', async () => {
+        const { service } = setupTest();
+
+        server.use(http.delete(`${baseUrl}/items/1`, () => HttpResponse.json(null)));
+
+        const result = await firstValueFrom(service.delete<null>(`${baseUrl}/items/1`));
+
+        expect(result).toBeNull();
+    });
+
+    it('propagates a non-2xx response as an error', async () => {
+        const { service } = setupTest();
+
+        server.use(http.get(`${baseUrl}/items`, () => new HttpResponse(null, { status: 404 })));
+
+        await expect(firstValueFrom(service.get(`${baseUrl}/items`))).rejects.toThrow('404');
+    });
+});

--- a/packages/arcane-ui/http/lib/request.service.ts
+++ b/packages/arcane-ui/http/lib/request.service.ts
@@ -1,0 +1,44 @@
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+
+/**
+ * Typed wrapper around Angular's {@link HttpClient}.
+ *
+ * Methods accept any full URL and return a typed `Observable`. Must be provided
+ * explicitly — use {@link provideHttpClient} alongside this service in your providers.
+ *
+ * @example
+ * bootstrapApplication(AppComponent, {
+ *   providers: [RequestService, provideHttpClient()],
+ * });
+ */
+@Injectable({ providedIn: null })
+export class RequestService {
+    private readonly httpClient = inject(HttpClient);
+
+    /** Sends a GET request to `url` and returns the typed response body. */
+    public get<T>(url: string): Observable<T> {
+        return this.httpClient.get<T>(url);
+    }
+
+    /** Sends a POST request to `url` with `body` and returns the typed response body. */
+    public post<T, B = unknown>(url: string, body: B): Observable<T> {
+        return this.httpClient.post<T>(url, body);
+    }
+
+    /** Sends a PUT request to `url` with `body` and returns the typed response body. */
+    public put<T, B = unknown>(url: string, body: B): Observable<T> {
+        return this.httpClient.put<T>(url, body);
+    }
+
+    /** Sends a PATCH request to `url` with `body` and returns the typed response body. */
+    public patch<T, B = unknown>(url: string, body: B): Observable<T> {
+        return this.httpClient.patch<T>(url, body);
+    }
+
+    /** Sends a DELETE request to `url` and returns the typed response body. */
+    public delete<T>(url: string): Observable<T> {
+        return this.httpClient.delete<T>(url);
+    }
+}

--- a/packages/arcane-ui/http/public-api.ts
+++ b/packages/arcane-ui/http/public-api.ts
@@ -1,1 +1,1 @@
-export {};
+export { RequestService } from './lib/request.service';


### PR DESCRIPTION
## Summary

### Context

`arcane-ui` lacked a typed abstraction over Angular's `HttpClient`. Services needing to make HTTP calls (starting with `ConfigService`) were using native `fetch()` directly, bypassing Angular's HTTP infrastructure.

### Changes

`RequestService` was added to the `http` entry point as an `@Injectable({ providedIn: null })` wrapper around `HttpClient`. It exposes typed `get<T>`, `post<T, B>`, `put<T, B>`, `patch<T, B>`, and `delete<T>` methods — each accepts a full URL and returns an `Observable<T>`. The service is exported from the `http` public API.

`ConfigService.load()` was migrated from native `fetch()` to `RequestService.get()`, routing the config bootstrap through Angular's HTTP stack. `provideConfig` was updated to include `RequestService` in its providers. Unit tests for all five `RequestService` methods were added using MSW, following the same pattern as the existing `ConfigService` tests.

## Test Plan

- [x] Run `pnpm --filter @dnd-mapp/arcane-ui test-ci` — all 15 tests pass with 100% coverage
- [x] Confirm `ConfigService` tests still pass (404 and network-error assertions hold via `HttpErrorResponse`)

Closes: #42