### PR TITLE
fix(workspace): Add stylelint to root devDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "playwright": "catalog:playwright",
     "prettier": "catalog:prettier",
     "prettier-plugin-organize-imports": "catalog:prettier",
+    "stylelint": "catalog:stylelint",
     "typescript": "catalog:",
     "typescript-eslint": "catalog:eslint"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -208,6 +208,9 @@ importers:
       prettier-plugin-organize-imports:
         specifier: catalog:prettier
         version: 4.3.0(prettier@3.8.3)(typescript@5.9.3)
+      stylelint:
+        specifier: catalog:stylelint
+        version: 17.12.0(typescript@5.9.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3


### PR DESCRIPTION
## Summary

### Context

Moving package dependencies from the root workspace into each individual package removed `stylelint` from the root `node_modules/.bin`. The pre-commit hook runs `lint-staged` from the root context, so when `lint-staged` attempted to run `stylelint` against staged SCSS files, the binary could not be found and the hook failed.

### Changes

`stylelint` has been added back to the root `devDependencies` using `catalog:stylelint`, matching the existing pattern for `eslint`. The package-level declarations in `sigil`, `arcane-ui`, and `realm` are unchanged — packages remain self-contained for their own tooling. The root entry exists solely to make the pre-commit hook's `stylelint` invocation resolvable.

## Test Plan

- [x] Stage a `.scss` file with a lint violation and confirm the pre-commit hook rejects the commit
- [x] Stage a clean `.scss` file and confirm the pre-commit hook passes