### PR TITLE
feat(theming): Implement ThemeService

### DIFF
--- a/packages/arcane-ui/theming/lib/theme-mode.ts
+++ b/packages/arcane-ui/theming/lib/theme-mode.ts
@@ -1,0 +1,9 @@
+/** Constant bag of the three valid theme mode values. Prefer these over raw strings to avoid typos. */
+export const ThemeModes = {
+    DARK: 'dark',
+    LIGHT: 'light',
+    SYSTEM: 'system',
+} as const;
+
+/** The union of valid theme modes accepted by {@link ThemeService.setTheme}. */
+export type ThemeMode = (typeof ThemeModes)[keyof typeof ThemeModes];

--- a/packages/arcane-ui/theming/lib/theme.service.spec.ts
+++ b/packages/arcane-ui/theming/lib/theme.service.spec.ts
@@ -1,0 +1,68 @@
+import { TestBed } from '@angular/core/testing';
+import { setupTestEnvironment } from '@dnd-mapp/arcane-ui/testing';
+import { ThemeModes } from './theme-mode';
+import { ThemeService } from './theme.service';
+
+describe('ThemeService', () => {
+    async function setupTest() {
+        await setupTestEnvironment({ providers: [ThemeService] });
+        return { service: TestBed.inject(ThemeService) };
+    }
+
+    afterEach(() => document.documentElement.removeAttribute('data-theme'));
+
+    it('initial mode is "system"', async () => {
+        const { service } = await setupTest();
+
+        expect(service.mode()).toBe(ThemeModes.SYSTEM);
+    });
+
+    it('initial state does not set [data-theme] on <html>', async () => {
+        await setupTest();
+
+        expect(document.documentElement.getAttribute('data-theme')).toBeNull();
+    });
+
+    it('setTheme("dark") writes [data-theme="dark"] to <html>', async () => {
+        const { service } = await setupTest();
+
+        service.setTheme(ThemeModes.DARK);
+        expect(document.documentElement.getAttribute('data-theme')).toBe(ThemeModes.DARK);
+    });
+
+    it('setTheme("light") writes [data-theme="light"] to <html>', async () => {
+        const { service } = await setupTest();
+
+        service.setTheme(ThemeModes.LIGHT);
+        expect(document.documentElement.getAttribute('data-theme')).toBe(ThemeModes.LIGHT);
+    });
+
+    it('setTheme("system") removes [data-theme] from <html>', async () => {
+        const { service } = await setupTest();
+
+        service.setTheme(ThemeModes.DARK);
+        service.setTheme(ThemeModes.SYSTEM);
+        expect(document.documentElement.getAttribute('data-theme')).toBeNull();
+    });
+
+    it('mode signal reflects the active mode after each transition', async () => {
+        const { service } = await setupTest();
+
+        service.setTheme(ThemeModes.DARK);
+        expect(service.mode()).toBe(ThemeModes.DARK);
+
+        service.setTheme(ThemeModes.LIGHT);
+        expect(service.mode()).toBe(ThemeModes.LIGHT);
+
+        service.setTheme(ThemeModes.SYSTEM);
+        expect(service.mode()).toBe(ThemeModes.SYSTEM);
+    });
+
+    it('switching from light to dark updates [data-theme]', async () => {
+        const { service } = await setupTest();
+
+        service.setTheme(ThemeModes.LIGHT);
+        service.setTheme(ThemeModes.DARK);
+        expect(document.documentElement.getAttribute('data-theme')).toBe(ThemeModes.DARK);
+    });
+});

--- a/packages/arcane-ui/theming/lib/theme.service.ts
+++ b/packages/arcane-ui/theming/lib/theme.service.ts
@@ -1,0 +1,46 @@
+import { DOCUMENT } from '@angular/common';
+import { inject, Injectable, signal } from '@angular/core';
+import { type ThemeMode, ThemeModes } from './theme-mode';
+
+/**
+ * Manages the active theme mode for the application.
+ *
+ * Must be provided explicitly — there is no default provider.
+ *
+ * @example
+ * bootstrapApplication(AppComponent, {
+ *   providers: [ThemeService],
+ * });
+ */
+@Injectable({ providedIn: null })
+export class ThemeService {
+    private readonly document = inject(DOCUMENT);
+
+    private readonly _mode = signal<ThemeMode>(ThemeModes.SYSTEM);
+
+    /** The currently active theme mode. Reflects the last value passed to {@link setTheme}, or `'system'` before any call. */
+    public readonly mode = this._mode.asReadonly();
+
+    constructor() {
+        this.applyTheme(ThemeModes.SYSTEM);
+    }
+
+    /**
+     * Switches the active theme mode.
+     *
+     * - `'dark'` / `'light'` — writes `[data-theme]` to `<html>`, overriding the CSS media query.
+     * - `'system'` — removes `[data-theme]`, letting `prefers-color-scheme` govern via the media query.
+     */
+    public setTheme(mode: ThemeMode): void {
+        this._mode.set(mode);
+        this.applyTheme(mode);
+    }
+
+    private applyTheme(mode: ThemeMode) {
+        if (mode === ThemeModes.SYSTEM) {
+            this.document.documentElement.removeAttribute('data-theme');
+        } else {
+            this.document.documentElement.setAttribute('data-theme', mode);
+        }
+    }
+}

--- a/packages/arcane-ui/theming/public-api.ts
+++ b/packages/arcane-ui/theming/public-api.ts
@@ -1,1 +1,2 @@
-export {};
+export type { ThemeMode } from './lib/theme-mode';
+export { ThemeService } from './lib/theme.service';


### PR DESCRIPTION
## Summary

### Context

The `theming` secondary entry point of `arcane-ui` was a stub with no implementation. Without `ThemeService`, consumers had no Angular-first way to manage theme switching between dark, light, and system modes.

### Changes

Add `ThemeModes` const, `ThemeMode` type, and `ThemeService` to the `theming` entry point. The service uses an Angular signal to track the active mode and exposes `setTheme()` to switch between `'dark'`, `'light'`, and `'system'`. Calling `setTheme('dark')` or `setTheme('light')` writes the `[data-theme]` attribute to `<html>`, overriding the CSS media query; `setTheme('system')` removes the attribute and defers theme resolution to `prefers-color-scheme`.

## Breaking Changes

None — the `theming` entry point was previously a stub with no exports.

## Test Plan

- [x] Run `pnpm test-ci` in `packages/arcane-ui` and confirm all 22 tests pass with 100% coverage
- [x] Import `ThemeService` from `@dnd-mapp/arcane-ui/theming` in a consumer app and provide it; call `setTheme('dark')` and confirm `<html data-theme="dark">` is set
- [x] Call `setTheme('system')` and confirm the `data-theme` attribute is removed from `<html>`
- [x] Verify `service.mode()` signal reflects the active mode after each `setTheme()` call

Closes: #36