### PR TITLE
Wire ThemeService persistence and Sigil into Realm

### DIFF
--- a/.run/arcane-ui-build-dev.run.xml
+++ b/.run/arcane-ui-build-dev.run.xml
@@ -1,10 +1,11 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="arcane-ui-build-dev" type="js.build_tools.npm" folderName="packages/arcane-ui">
-    <package-json value="$PROJECT_DIR$/packages/arcane-ui/package.json" />
+    <package-json value="$PROJECT_DIR$/package.json" />
     <command value="run" />
     <scripts>
-      <script value="build-dev" />
+      <script value="moon" />
     </scripts>
+    <arguments value="run arcane-ui:build-dev" />
     <node-interpreter value="project" />
     <envs />
     <EXTENSION ID="com.github.l34130.mise.core.run.MiseRunConfigurationSettingsEditor" myConfigEnvironmentStrategy="use_project_settings" myMiseDirEnvCb="false" myMiseConfigEnvironmentTf="" />

--- a/.run/arcane-ui-build.run.xml
+++ b/.run/arcane-ui-build.run.xml
@@ -1,10 +1,11 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="arcane-ui-build" type="js.build_tools.npm" folderName="packages/arcane-ui">
-    <package-json value="$PROJECT_DIR$/packages/arcane-ui/package.json" />
+    <package-json value="$PROJECT_DIR$/package.json" />
     <command value="run" />
     <scripts>
-      <script value="build" />
+      <script value="moon" />
     </scripts>
+    <arguments value="run arcane-ui:build" />
     <node-interpreter value="project" />
     <envs />
     <EXTENSION ID="com.github.l34130.mise.core.run.MiseRunConfigurationSettingsEditor" myConfigEnvironmentStrategy="use_project_settings" myMiseDirEnvCb="false" myMiseConfigEnvironmentTf="" />

--- a/.run/arcane-ui-lint-css.run.xml
+++ b/.run/arcane-ui-lint-css.run.xml
@@ -1,10 +1,11 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="arcane-ui-lint-css" type="js.build_tools.npm" folderName="packages/arcane-ui">
-    <package-json value="$PROJECT_DIR$/packages/arcane-ui/package.json" />
+    <package-json value="$PROJECT_DIR$/package.json" />
     <command value="run" />
     <scripts>
-      <script value="lint-css" />
+      <script value="moon" />
     </scripts>
+    <arguments value="run arcane-ui:lint-css" />
     <node-interpreter value="project" />
     <envs />
     <EXTENSION ID="com.github.l34130.mise.core.run.MiseRunConfigurationSettingsEditor" myConfigEnvironmentStrategy="use_project_settings" myMiseDirEnvCb="false" myMiseConfigEnvironmentTf="" />

--- a/.run/arcane-ui-lint-ts.run.xml
+++ b/.run/arcane-ui-lint-ts.run.xml
@@ -1,10 +1,11 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="arcane-ui-lint-ts" type="js.build_tools.npm" folderName="packages/arcane-ui">
-    <package-json value="$PROJECT_DIR$/packages/arcane-ui/package.json" />
+    <package-json value="$PROJECT_DIR$/package.json" />
     <command value="run" />
     <scripts>
-      <script value="lint-ts" />
+      <script value="moon" />
     </scripts>
+    <arguments value="run arcane-ui:lint-ts" />
     <node-interpreter value="project" />
     <envs />
     <EXTENSION ID="com.github.l34130.mise.core.run.MiseRunConfigurationSettingsEditor" myConfigEnvironmentStrategy="use_project_settings" myMiseDirEnvCb="false" myMiseConfigEnvironmentTf="" />

--- a/.run/arcane-ui-test-ci.run.xml
+++ b/.run/arcane-ui-test-ci.run.xml
@@ -1,10 +1,11 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="arcane-ui-test-ci" type="js.build_tools.npm" folderName="packages/arcane-ui">
-    <package-json value="$PROJECT_DIR$/packages/arcane-ui/package.json" />
+    <package-json value="$PROJECT_DIR$/package.json" />
     <command value="run" />
     <scripts>
-      <script value="test-ci" />
+      <script value="moon" />
     </scripts>
+    <arguments value="run arcane-ui:test-ci" />
     <node-interpreter value="project" />
     <envs />
     <EXTENSION ID="com.github.l34130.mise.core.run.MiseRunConfigurationSettingsEditor" myConfigEnvironmentStrategy="use_project_settings" myMiseDirEnvCb="false" myMiseConfigEnvironmentTf="" />

--- a/.run/arcane-ui-test.run.xml
+++ b/.run/arcane-ui-test.run.xml
@@ -1,10 +1,11 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="arcane-ui-test" type="js.build_tools.npm" folderName="packages/arcane-ui">
-    <package-json value="$PROJECT_DIR$/packages/arcane-ui/package.json" />
+    <package-json value="$PROJECT_DIR$/package.json" />
     <command value="run" />
     <scripts>
-      <script value="test" />
+      <script value="moon" />
     </scripts>
+    <arguments value="run arcane-ui:test" />
     <node-interpreter value="project" />
     <envs />
     <EXTENSION ID="com.github.l34130.mise.core.run.MiseRunConfigurationSettingsEditor" myConfigEnvironmentStrategy="use_project_settings" myMiseDirEnvCb="false" myMiseConfigEnvironmentTf="" />

--- a/.run/format-check.run.xml
+++ b/.run/format-check.run.xml
@@ -1,10 +1,11 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="format-check" type="js.build_tools.npm" folderName="formatting">
+  <configuration default="false" name="format-check" type="js.build_tools.npm" folderName="root">
     <package-json value="$PROJECT_DIR$/package.json" />
     <command value="run" />
     <scripts>
-      <script value="format-check" />
+      <script value="moon" />
     </scripts>
+    <arguments value="run root:format:check" />
     <node-interpreter value="project" />
     <envs />
     <EXTENSION ID="com.github.l34130.mise.core.run.MiseRunConfigurationSettingsEditor" myConfigEnvironmentStrategy="use_project_settings" myMiseDirEnvCb="false" myMiseConfigEnvironmentTf="" />

--- a/.run/format.run.xml
+++ b/.run/format.run.xml
@@ -1,10 +1,11 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="format" type="js.build_tools.npm" folderName="formatting" nameIsGenerated="true">
+  <configuration default="false" name="format" type="js.build_tools.npm" folderName="root">
     <package-json value="$PROJECT_DIR$/package.json" />
     <command value="run" />
     <scripts>
-      <script value="format" />
+      <script value="moon" />
     </scripts>
+    <arguments value="run root:format" />
     <node-interpreter value="project" />
     <envs />
     <EXTENSION ID="com.github.l34130.mise.core.run.MiseRunConfigurationSettingsEditor" myConfigEnvironmentStrategy="use_project_settings" myMiseDirEnvCb="false" myMiseConfigEnvironmentTf="" />

--- a/.run/lint-md.run.xml
+++ b/.run/lint-md.run.xml
@@ -1,10 +1,11 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="lint-md" type="js.build_tools.npm" folderName="linting">
+  <configuration default="false" name="lint-md" type="js.build_tools.npm" folderName="root">
     <package-json value="$PROJECT_DIR$/package.json" />
     <command value="run" />
     <scripts>
-      <script value="lint-md" />
+      <script value="moon" />
     </scripts>
+    <arguments value="run root:lint-md" />
     <node-interpreter value="project" />
     <envs />
     <EXTENSION ID="com.github.l34130.mise.core.run.MiseRunConfigurationSettingsEditor" myConfigEnvironmentStrategy="use_project_settings" myMiseDirEnvCb="false" myMiseConfigEnvironmentTf="" />

--- a/.run/lint-ts.run.xml
+++ b/.run/lint-ts.run.xml
@@ -1,10 +1,11 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="lint-ts" type="js.build_tools.npm" folderName="linting">
+  <configuration default="false" name="lint-ts" type="js.build_tools.npm" folderName="root">
     <package-json value="$PROJECT_DIR$/package.json" />
     <command value="run" />
     <scripts>
-      <script value="lint-ts" />
+      <script value="moon" />
     </scripts>
+    <arguments value="run root:lint-ts" />
     <node-interpreter value="project" />
     <envs />
     <EXTENSION ID="com.github.l34130.mise.core.run.MiseRunConfigurationSettingsEditor" myConfigEnvironmentStrategy="use_project_settings" myMiseDirEnvCb="false" myMiseConfigEnvironmentTf="" />

--- a/.run/realm-build.run.xml
+++ b/.run/realm-build.run.xml
@@ -1,10 +1,11 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="realm-build" type="js.build_tools.npm" folderName="apps/realm">
-    <package-json value="$PROJECT_DIR$/apps/realm/package.json" />
+    <package-json value="$PROJECT_DIR$/package.json" />
     <command value="run" />
     <scripts>
-      <script value="build" />
+      <script value="moon" />
     </scripts>
+    <arguments value="run realm:build" />
     <node-interpreter value="project" />
     <envs />
     <EXTENSION ID="com.github.l34130.mise.core.run.MiseRunConfigurationSettingsEditor" myConfigEnvironmentStrategy="use_project_settings" myMiseDirEnvCb="false" myMiseConfigEnvironmentTf="" />

--- a/.run/realm-e2e-ci.run.xml
+++ b/.run/realm-e2e-ci.run.xml
@@ -1,10 +1,11 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="realm-e2e-ci" type="js.build_tools.npm" folderName="e2e/realm">
-    <package-json value="$PROJECT_DIR$/e2e/realm/package.json" />
+    <package-json value="$PROJECT_DIR$/package.json" />
     <command value="run" />
     <scripts>
-      <script value="test-ci" />
+      <script value="moon" />
     </scripts>
+    <arguments value="run realm-e2e:e2e-ci" />
     <node-interpreter value="project" />
     <envs />
     <EXTENSION ID="com.github.l34130.mise.core.run.MiseRunConfigurationSettingsEditor" myConfigEnvironmentStrategy="use_project_settings" myMiseDirEnvCb="false" myMiseConfigEnvironmentTf="" />

--- a/.run/realm-e2e-lint-ts.run.xml
+++ b/.run/realm-e2e-lint-ts.run.xml
@@ -1,10 +1,11 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="realm-e2e-lint-ts" type="js.build_tools.npm" folderName="e2e/realm">
-    <package-json value="$PROJECT_DIR$/e2e/realm/package.json" />
+    <package-json value="$PROJECT_DIR$/package.json" />
     <command value="run" />
     <scripts>
-      <script value="lint-ts" />
+      <script value="moon" />
     </scripts>
+    <arguments value="run realm-e2e:lint-ts" />
     <node-interpreter value="project" />
     <envs />
     <EXTENSION ID="com.github.l34130.mise.core.run.MiseRunConfigurationSettingsEditor" myConfigEnvironmentStrategy="use_project_settings" myMiseDirEnvCb="false" myMiseConfigEnvironmentTf="" />

--- a/.run/realm-e2e.run.xml
+++ b/.run/realm-e2e.run.xml
@@ -1,10 +1,11 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="realm-e2e-dev" type="js.build_tools.npm" folderName="e2e/realm">
-    <package-json value="$PROJECT_DIR$/e2e/realm/package.json" />
+  <configuration default="false" name="realm-e2e" type="js.build_tools.npm" folderName="e2e/realm">
+    <package-json value="$PROJECT_DIR$/package.json" />
     <command value="run" />
     <scripts>
-      <script value="test-dev" />
+      <script value="moon" />
     </scripts>
+    <arguments value="run realm-e2e:e2e" />
     <node-interpreter value="project" />
     <envs />
     <EXTENSION ID="com.github.l34130.mise.core.run.MiseRunConfigurationSettingsEditor" myConfigEnvironmentStrategy="use_project_settings" myMiseDirEnvCb="false" myMiseConfigEnvironmentTf="" />

--- a/.run/realm-lint-css.run.xml
+++ b/.run/realm-lint-css.run.xml
@@ -1,10 +1,11 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="realm-lint-css" type="js.build_tools.npm" folderName="apps/realm">
-    <package-json value="$PROJECT_DIR$/apps/realm/package.json" />
+    <package-json value="$PROJECT_DIR$/package.json" />
     <command value="run" />
     <scripts>
-      <script value="lint-css" />
+      <script value="moon" />
     </scripts>
+    <arguments value="run realm:lint-css" />
     <node-interpreter value="project" />
     <envs />
     <EXTENSION ID="com.github.l34130.mise.core.run.MiseRunConfigurationSettingsEditor" myConfigEnvironmentStrategy="use_project_settings" myMiseDirEnvCb="false" myMiseConfigEnvironmentTf="" />

--- a/.run/realm-lint-ts.run.xml
+++ b/.run/realm-lint-ts.run.xml
@@ -1,10 +1,11 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="realm-lint-ts" type="js.build_tools.npm" folderName="apps/realm">
-    <package-json value="$PROJECT_DIR$/apps/realm/package.json" />
+    <package-json value="$PROJECT_DIR$/package.json" />
     <command value="run" />
     <scripts>
-      <script value="lint-ts" />
+      <script value="moon" />
     </scripts>
+    <arguments value="run realm:line-ts" />
     <node-interpreter value="project" />
     <envs />
     <EXTENSION ID="com.github.l34130.mise.core.run.MiseRunConfigurationSettingsEditor" myConfigEnvironmentStrategy="use_project_settings" myMiseDirEnvCb="false" myMiseConfigEnvironmentTf="" />

--- a/.run/realm-start.run.xml
+++ b/.run/realm-start.run.xml
@@ -1,10 +1,11 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="realm-start" type="js.build_tools.npm" folderName="apps/realm">
-    <package-json value="$PROJECT_DIR$/apps/realm/package.json" />
+    <package-json value="$PROJECT_DIR$/package.json" />
     <command value="run" />
     <scripts>
-      <script value="start" />
+      <script value="moon" />
     </scripts>
+    <arguments value="run realm:start" />
     <node-interpreter value="project" />
     <envs />
     <EXTENSION ID="com.github.l34130.mise.core.run.MiseRunConfigurationSettingsEditor" myConfigEnvironmentStrategy="use_project_settings" myMiseDirEnvCb="false" myMiseConfigEnvironmentTf="" />

--- a/.run/realm-test-ci.run.xml
+++ b/.run/realm-test-ci.run.xml
@@ -1,10 +1,11 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="realm-test-ci" type="js.build_tools.npm" folderName="apps/realm">
-    <package-json value="$PROJECT_DIR$/apps/realm/package.json" />
+    <package-json value="$PROJECT_DIR$/package.json" />
     <command value="run" />
     <scripts>
-      <script value="test-ci" />
+      <script value="moon" />
     </scripts>
+    <arguments value="run realm:test-ci" />
     <node-interpreter value="project" />
     <envs />
     <EXTENSION ID="com.github.l34130.mise.core.run.MiseRunConfigurationSettingsEditor" myConfigEnvironmentStrategy="use_project_settings" myMiseDirEnvCb="false" myMiseConfigEnvironmentTf="" />

--- a/.run/realm-test.run.xml
+++ b/.run/realm-test.run.xml
@@ -1,10 +1,11 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="realm-test" type="js.build_tools.npm" folderName="apps/realm">
-    <package-json value="$PROJECT_DIR$/apps/realm/package.json" />
+    <package-json value="$PROJECT_DIR$/package.json" />
     <command value="run" />
     <scripts>
-      <script value="test" />
+      <script value="moon" />
     </scripts>
+    <arguments value="run realm:test" />
     <node-interpreter value="project" />
     <envs />
     <EXTENSION ID="com.github.l34130.mise.core.run.MiseRunConfigurationSettingsEditor" myConfigEnvironmentStrategy="use_project_settings" myMiseDirEnvCb="false" myMiseConfigEnvironmentTf="" />

--- a/.run/sigil-build-dev.run.xml
+++ b/.run/sigil-build-dev.run.xml
@@ -1,10 +1,11 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="sigil-build-dev" type="js.build_tools.npm" folderName="packages/sigil">
-    <package-json value="$PROJECT_DIR$/packages/sigil/package.json" />
+    <package-json value="$PROJECT_DIR$/package.json" />
     <command value="run" />
     <scripts>
-      <script value="build-dev" />
+      <script value="moon" />
     </scripts>
+    <arguments value="run sigil:build-dev" />
     <node-interpreter value="project" />
     <envs />
     <EXTENSION ID="com.github.l34130.mise.core.run.MiseRunConfigurationSettingsEditor" myConfigEnvironmentStrategy="use_project_settings" myMiseDirEnvCb="false" myMiseConfigEnvironmentTf="" />

--- a/.run/sigil-build.run.xml
+++ b/.run/sigil-build.run.xml
@@ -1,10 +1,11 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="sigil-build" type="js.build_tools.npm" folderName="packages/sigil">
-    <package-json value="$PROJECT_DIR$/packages/sigil/package.json" />
+    <package-json value="$PROJECT_DIR$/package.json" />
     <command value="run" />
     <scripts>
-      <script value="build" />
+      <script value="moon" />
     </scripts>
+    <arguments value="run sigil:build" />
     <node-interpreter value="project" />
     <envs />
     <EXTENSION ID="com.github.l34130.mise.core.run.MiseRunConfigurationSettingsEditor" myConfigEnvironmentStrategy="use_project_settings" myMiseDirEnvCb="false" myMiseConfigEnvironmentTf="" />

--- a/.run/sigil-lint-css.run.xml
+++ b/.run/sigil-lint-css.run.xml
@@ -1,10 +1,11 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="sigil-lint-css" type="js.build_tools.npm" folderName="packages/sigil">
-    <package-json value="$PROJECT_DIR$/packages/sigil/package.json" />
+    <package-json value="$PROJECT_DIR$/package.json" />
     <command value="run" />
     <scripts>
-      <script value="lint-css" />
+      <script value="moon" />
     </scripts>
+    <arguments value="run sigil:lint-css" />
     <node-interpreter value="project" />
     <envs />
     <EXTENSION ID="com.github.l34130.mise.core.run.MiseRunConfigurationSettingsEditor" myConfigEnvironmentStrategy="use_project_settings" myMiseDirEnvCb="false" myMiseConfigEnvironmentTf="" />

--- a/apps/realm/angular.json
+++ b/apps/realm/angular.json
@@ -26,7 +26,7 @@
                         "index": "./src/index.html",
                         "inlineStyleLanguage": "scss",
                         "outputPath": "dist",
-                        "styles": ["./src/main.scss"],
+                        "styles": ["node_modules/@dnd-mapp/sigil/index.css", "./src/main.scss"],
                         "tsConfig": "./tsconfig.app.json"
                     },
                     "defaultConfiguration": "production",

--- a/apps/realm/core/src/config/app.config.ts
+++ b/apps/realm/core/src/config/app.config.ts
@@ -2,6 +2,7 @@ import { provideHttpClient, withFetch } from '@angular/common/http';
 import { type ApplicationConfig, provideZonelessChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { provideConfig } from '@dnd-mapp/arcane-ui/config';
+import { provideTheme } from '@dnd-mapp/arcane-ui/theming';
 import { routes } from './app.routes';
 import { type RealmConfig } from './realm-config';
 
@@ -11,5 +12,6 @@ export const appConfig: ApplicationConfig = {
         provideRouter(routes),
         provideHttpClient(withFetch()),
         ...provideConfig<RealmConfig>('/config.json'),
+        ...provideTheme(),
     ],
 };

--- a/apps/realm/moon.yml
+++ b/apps/realm/moon.yml
@@ -8,11 +8,15 @@ tasks:
     start:
         command: 'pnpm start'
         preset: 'server'
+        deps:
+            - 'arcane-ui:build'
+            - 'sigil:build'
 
     build:
         command: 'pnpm build'
         deps:
             - 'arcane-ui:build'
+            - 'sigil:build'
         inputs:
             - 'src/**/*'
             - 'public/**/*'
@@ -30,6 +34,7 @@ tasks:
         command: 'pnpm test-ci'
         deps:
             - 'arcane-ui:build'
+            - 'sigil:build'
             - 'root:playwright-install'
         inputs:
             - 'src/**/*'
@@ -49,6 +54,7 @@ tasks:
         command: 'pnpm test'
         preset: 'server'
         deps:
+            - 'sigil:build'
             - 'root:playwright-install'
 
     lint-ts:

--- a/apps/realm/package.json
+++ b/apps/realm/package.json
@@ -29,6 +29,7 @@
     "@angular/platform-browser-dynamic": "catalog:angular",
     "@angular/router": "catalog:angular",
     "@dnd-mapp/arcane-ui": "workspace:*",
+    "@dnd-mapp/sigil": "workspace:*",
     "@ngrx/signals": "catalog:ngrx",
     "rxjs": "catalog:",
     "tslib": "catalog:"

--- a/e2e/realm/moon.yml
+++ b/e2e/realm/moon.yml
@@ -8,16 +8,6 @@ dependsOn:
     - realm
 
 tasks:
-    lint-ts:
-        command: 'pnpm lint-ts'
-        inputs:
-            - 'src/**/*.ts'
-            - 'playwright.config.ts'
-            - 'eslint.config.mjs'
-            - 'tsconfig.json'
-            - '/tsconfig.base.json'
-            - '/packages/eslint-config/src/**/*.mjs'
-
     e2e-ci:
         command: 'pnpm e2e-ci'
         deps:
@@ -39,3 +29,12 @@ tasks:
         preset: 'server'
         deps:
             - 'root:playwright-install'
+    lint-ts:
+        command: 'pnpm lint-ts'
+        inputs:
+            - 'src/**/*.ts'
+            - 'playwright.config.ts'
+            - 'eslint.config.mjs'
+            - 'tsconfig.json'
+            - '/tsconfig.base.json'
+            - '/packages/eslint-config/src/**/*.mjs'

--- a/packages/arcane-ui/storage/testing/lib/mock-storage.ts
+++ b/packages/arcane-ui/storage/testing/lib/mock-storage.ts
@@ -11,6 +11,14 @@
 export class MockStorage implements Storage {
     private store: Record<string, string> = {};
 
+    constructor(store?: Record<string, unknown>) {
+        if (store) {
+            for (const [key, value] of Object.entries(store)) {
+                this.store[key] = JSON.stringify(value);
+            }
+        }
+    }
+
     public get length(): number {
         return Object.keys(this.store).length;
     }

--- a/packages/arcane-ui/theming/lib/provide-theme.ts
+++ b/packages/arcane-ui/theming/lib/provide-theme.ts
@@ -1,0 +1,16 @@
+import { type Provider } from '@angular/core';
+import { provideStorage } from '@dnd-mapp/arcane-ui/common';
+import { StorageService } from '@dnd-mapp/arcane-ui/storage';
+import { ThemeService } from './theme.service';
+
+/**
+ * Wires up {@link ThemeService} with `localStorage` persistence.
+ *
+ * @example
+ * bootstrapApplication(AppComponent, {
+ *   providers: [...provideTheme()],
+ * });
+ */
+export function provideTheme(): Provider[] {
+    return [...provideStorage(localStorage), StorageService, ThemeService];
+}

--- a/packages/arcane-ui/theming/lib/theme-mode.ts
+++ b/packages/arcane-ui/theming/lib/theme-mode.ts
@@ -7,3 +7,8 @@ export const ThemeModes = {
 
 /** The union of valid theme modes accepted by {@link ThemeService.setTheme}. */
 export type ThemeMode = (typeof ThemeModes)[keyof typeof ThemeModes];
+
+/** Returns `true` if `value` is a valid {@link ThemeMode}. */
+export function isThemeMode(value: unknown): value is ThemeMode {
+    return Object.values(ThemeModes).includes(value as ThemeMode);
+}

--- a/packages/arcane-ui/theming/lib/theme.service.spec.ts
+++ b/packages/arcane-ui/theming/lib/theme.service.spec.ts
@@ -1,12 +1,27 @@
 import { TestBed } from '@angular/core/testing';
+import { provideStorage, STORAGE } from '@dnd-mapp/arcane-ui/common';
+import { StorageService } from '@dnd-mapp/arcane-ui/storage';
+import { MockStorage } from '@dnd-mapp/arcane-ui/storage/testing';
 import { setupTestEnvironment } from '@dnd-mapp/arcane-ui/testing';
 import { ThemeModes } from './theme-mode';
 import { ThemeService } from './theme.service';
 
 describe('ThemeService', () => {
-    async function setupTest() {
-        await setupTestEnvironment({ providers: [ThemeService] });
-        return { service: TestBed.inject(ThemeService) };
+    interface SetupTestParams {
+        store: Record<string, unknown>;
+    }
+
+    async function setupTest(params?: SetupTestParams) {
+        const mockStorage = new MockStorage(params?.store ? params.store : {});
+
+        await setupTestEnvironment({
+            providers: [...provideStorage(mockStorage), StorageService, ThemeService],
+        });
+
+        return {
+            service: TestBed.inject(ThemeService),
+            mockStorage: TestBed.inject(STORAGE) as MockStorage,
+        };
     }
 
     afterEach(() => document.documentElement.removeAttribute('data-theme'));
@@ -64,5 +79,39 @@ describe('ThemeService', () => {
         service.setTheme(ThemeModes.LIGHT);
         service.setTheme(ThemeModes.DARK);
         expect(document.documentElement.getAttribute('data-theme')).toBe(ThemeModes.DARK);
+    });
+
+    it('constructor reads a stored "dark" preference', async () => {
+        const { service } = await setupTest({ store: { theme: ThemeModes.DARK } });
+
+        expect(service.mode()).toBe(ThemeModes.DARK);
+        expect(document.documentElement.getAttribute('data-theme')).toBe(ThemeModes.DARK);
+    });
+
+    it('constructor falls back to SYSTEM when nothing is stored', async () => {
+        const { service } = await setupTest();
+
+        expect(service.mode()).toBe(ThemeModes.SYSTEM);
+    });
+
+    it('constructor falls back to SYSTEM for an invalid stored value', async () => {
+        const { service } = await setupTest({ store: { theme: 'not-a-mode' } });
+
+        expect(service.mode()).toBe(ThemeModes.SYSTEM);
+    });
+
+    it('setTheme("dark") persists the value to storage', async () => {
+        const { service, mockStorage } = await setupTest();
+
+        service.setTheme(ThemeModes.DARK);
+        expect(mockStorage.getItem('theme')).toBe('"dark"');
+    });
+
+    it('setTheme("system") removes the preference from storage', async () => {
+        const { service, mockStorage } = await setupTest();
+
+        service.setTheme(ThemeModes.DARK);
+        service.setTheme(ThemeModes.SYSTEM);
+        expect(mockStorage.getItem('theme')).toBeNull();
     });
 });

--- a/packages/arcane-ui/theming/lib/theme.service.ts
+++ b/packages/arcane-ui/theming/lib/theme.service.ts
@@ -1,39 +1,53 @@
 import { DOCUMENT } from '@angular/common';
 import { inject, Injectable, signal } from '@angular/core';
-import { type ThemeMode, ThemeModes } from './theme-mode';
+import { StorageService } from '@dnd-mapp/arcane-ui/storage';
+import { isThemeMode, type ThemeMode, ThemeModes } from './theme-mode';
+
+const THEME_STORAGE_KEY = 'theme';
 
 /**
- * Manages the active theme mode for the application.
+ * Manages the active theme mode for the application, persisting the user's
+ * preference to storage across page reloads.
  *
- * Must be provided explicitly — there is no default provider.
- *
- * @example
- * bootstrapApplication(AppComponent, {
- *   providers: [ThemeService],
- * });
+ * Must be provided explicitly — use {@link provideTheme} at application level.
  */
 @Injectable({ providedIn: null })
 export class ThemeService {
     private readonly document = inject(DOCUMENT);
+    private readonly storage = inject(StorageService);
 
     private readonly _mode = signal<ThemeMode>(ThemeModes.SYSTEM);
 
-    /** The currently active theme mode. Reflects the last value passed to {@link setTheme}, or `'system'` before any call. */
+    /** The currently active theme mode. */
     public readonly mode = this._mode.asReadonly();
 
     constructor() {
-        this.applyTheme(ThemeModes.SYSTEM);
+        this.restorePersistedTheme();
     }
 
     /**
      * Switches the active theme mode.
      *
-     * - `'dark'` / `'light'` — writes `[data-theme]` to `<html>`, overriding the CSS media query.
-     * - `'system'` — removes `[data-theme]`, letting `prefers-color-scheme` govern via the media query.
+     * - `'dark'` / `'light'` — writes `[data-theme]` to `<html>` and persists the preference.
+     * - `'system'` — removes `[data-theme]` and clears the stored preference.
      */
     public setTheme(mode: ThemeMode): void {
         this._mode.set(mode);
+
+        if (mode === ThemeModes.SYSTEM) {
+            this.storage.remove(THEME_STORAGE_KEY);
+        } else {
+            this.storage.set(THEME_STORAGE_KEY, mode);
+        }
         this.applyTheme(mode);
+    }
+
+    private restorePersistedTheme() {
+        const stored = this.storage.get<ThemeMode>(THEME_STORAGE_KEY);
+        const initial = isThemeMode(stored) ? stored : ThemeModes.SYSTEM;
+
+        this._mode.set(initial);
+        this.applyTheme(initial);
     }
 
     private applyTheme(mode: ThemeMode) {

--- a/packages/arcane-ui/theming/public-api.ts
+++ b/packages/arcane-ui/theming/public-api.ts
@@ -1,2 +1,3 @@
-export type { ThemeMode } from './lib/theme-mode';
+export { provideTheme } from './lib/provide-theme';
+export { isThemeMode, type ThemeMode } from './lib/theme-mode';
 export { ThemeService } from './lib/theme.service';

--- a/packages/sigil/package.json
+++ b/packages/sigil/package.json
@@ -19,6 +19,9 @@
     },
     "./assets/fonts/*": "./assets/fonts/*"
   },
+  "publishConfig": {
+    "directory": "dist"
+  },
   "private": true,
   "engines": {
     "node": ">=24.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -250,6 +250,9 @@ importers:
       '@dnd-mapp/arcane-ui':
         specifier: workspace:*
         version: link:../../packages/arcane-ui/dist/arcane-ui
+      '@dnd-mapp/sigil':
+        specifier: workspace:*
+        version: link:../../packages/sigil/dist
       '@ngrx/signals':
         specifier: catalog:ngrx
         version: 21.1.0(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.2))(rxjs@7.8.2)
@@ -512,6 +515,7 @@ importers:
       stylelint-order:
         specifier: catalog:stylelint
         version: 8.1.1(stylelint@17.12.0(typescript@5.9.3))
+    publishDirectory: dist
 
   packages/stylelint-config:
     dependencies:


### PR DESCRIPTION
## Summary

### Context

`ThemeService` managed theme mode (dark/light/system) in-memory only, so the user's preference was lost on every page reload. Additionally, the Sigil design token package — which provides the app's CSS custom properties, fonts, and color tokens — was not yet wired into Realm, meaning the app had no access to the design system at runtime.

### Changes

- Added `isThemeMode()` type guard to `theme-mode.ts` and a new `provideTheme()` convenience function that bundles `ThemeService` with `StorageService` and a `localStorage` backend.
- `ThemeService` now injects `StorageService`, reads the stored preference on init via `restorePersistedTheme()`, and persists or removes the key on every `setTheme()` call; selecting system mode clears the key.
- `MockStorage` gains an optional constructor parameter that accepts a `Record<string, unknown>` and JSON-serializes the values, making constructor-read tests simpler to set up.
- Added `publishConfig.directory: "dist"` to Sigil's `package.json` so pnpm symlinks `node_modules/@dnd-mapp/sigil` to the build output.
- Realm now declares `@dnd-mapp/sigil` as a dependency, registers its compiled CSS before `main.scss` in `angular.json`, and registers `provideTheme()` in `app.config.ts`.
- All Realm Moon tasks that trigger a build (`start`, `build`, `test`, `test-ci`) now declare `sigil:build` as a dep.
- IDE run configurations updated to invoke tasks via `moon run` instead of `pnpm` directly.

## Test Plan

- [x] Run `pnpm --filter @dnd-mapp/arcane-ui test-ci` — all 27 tests pass, including 5 new ThemeService persistence tests.
- [x] Run `pnpm --filter @dnd-mapp/realm build` — build succeeds with Sigil CSS bundled (check `styles-*.css` is ~5 kB).
- [x] Start Realm dev server, open the app, set theme to dark, reload — confirm `[data-theme="dark"]` is still on `<html>`.

Closes: #37