### PR TITLE
ci(workflows): Fix coverage paths, add arcane-ui

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -34,10 +34,18 @@ jobs:
               with:
                   access-token: ${{ secrets.GITHUB_TOKEN }}
 
-            - name: Upload code coverage
-              if: hashFiles('coverage/apps/realm/cobertura-coverage.xml') != ''
+            - name: Upload code coverage (realm)
+              if: hashFiles('apps/realm/coverage/cobertura-coverage.xml') != ''
               uses: actions/upload-code-coverage@abb5995db9e0199b0e2bb9dbd136fce4cb1ec4d3 # v1.3.0
               with:
-                  file: coverage/apps/realm/cobertura-coverage.xml
+                  file: apps/realm/coverage/cobertura-coverage.xml
                   language: javascript
                   label: realm
+
+            - name: Upload code coverage (arcane-ui)
+              if: hashFiles('packages/arcane-ui/coverage/cobertura-coverage.xml') != ''
+              uses: actions/upload-code-coverage@abb5995db9e0199b0e2bb9dbd136fce4cb1ec4d3 # v1.3.0
+              with:
+                  file: packages/arcane-ui/coverage/cobertura-coverage.xml
+                  language: javascript
+                  label: arcane-ui

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -28,10 +28,18 @@ jobs:
             - name: Run CI
               run: pnpm moon ci
 
-            - name: Upload code coverage
-              if: hashFiles('coverage/apps/realm/cobertura-coverage.xml') != ''
+            - name: Upload code coverage (realm)
+              if: hashFiles('apps/realm/coverage/cobertura-coverage.xml') != ''
               uses: actions/upload-code-coverage@abb5995db9e0199b0e2bb9dbd136fce4cb1ec4d3 # v1.3.0
               with:
-                  file: coverage/apps/realm/cobertura-coverage.xml
+                  file: apps/realm/coverage/cobertura-coverage.xml
                   language: javascript
                   label: realm
+
+            - name: Upload code coverage (arcane-ui)
+              if: hashFiles('packages/arcane-ui/coverage/cobertura-coverage.xml') != ''
+              uses: actions/upload-code-coverage@abb5995db9e0199b0e2bb9dbd136fce4cb1ec4d3 # v1.3.0
+              with:
+                  file: packages/arcane-ui/coverage/cobertura-coverage.xml
+                  language: javascript
+                  label: arcane-ui


### PR DESCRIPTION
## Summary

### Context

Coverage reports for Realm and Arcane UI land at project-local paths (`apps/realm/coverage/` and `packages/arcane-ui/coverage/` respectively), consistent with how Moon declares task outputs. The CI upload steps were still pointing at a stale root-level path (`coverage/apps/realm/`) that no longer exists, causing the upload to silently skip on every run.

### Changes

Corrected the Realm coverage path in both workflow files and added a separate, independently-guarded upload step for Arcane UI. Each step uses `hashFiles` so it only fires when the corresponding coverage file was actually produced — this handles Moon's affected-only CI mode, where a project's test task may be skipped entirely.

## Breaking Changes

None.

## Test Plan

- [x] Trigger a PR that touches Realm — confirm the Realm upload step runs and reports `apps/realm/coverage/cobertura-coverage.xml`.
- [x] Trigger a PR that touches Arcane UI — confirm the Arcane UI upload step runs and reports `packages/arcane-ui/coverage/cobertura-coverage.xml`.
- [x] Trigger a PR that touches neither — confirm both upload steps are skipped.