### PR TITLE
docs(adr): Fix OAuth scope in ADR 0017

### DIFF
--- a/docs/adr/0017-remote-caching-via-bazel-remote-on-tailscale.md
+++ b/docs/adr/0017-remote-caching-via-bazel-remote-on-tailscale.md
@@ -19,7 +19,7 @@ Enable Moon remote caching in CI against the self-hosted `bazel-remote` instance
 
 **Tailscale for CI connectivity:** GitHub Actions runners are not on the tailnet by default. Each CI job joins the tailnet at the start of the run using the `tailscale/tailscale-github-action` with an OAuth client (`TS_OAUTH_CLIENT_ID`, `TS_OAUTH_SECRET`). Nodes join with the `tag:github-actions` ACL tag, which scopes their tailnet permissions. Ephemeral nodes created this way auto-expire when the job ends — no manual cleanup required.
 
-The OAuth client requires two scopes: `devices:core` (read+write) and `keys:auth_keys` (read+write). The action generates an ephemeral pre-auth key via the Tailscale API before calling `tailscale up`; key creation hits a separate API endpoint that `devices:core` alone does not cover. Omitting `keys:auth_keys` produces a `403 - calling actor does not have enough permissions` error at the `tailscale up` step.
+The OAuth client requires the `keys:auth_keys` scope (read+write). The action generates an ephemeral pre-auth key via the Tailscale API before calling `tailscale up`; omitting this scope produces a `403 - calling actor does not have enough permissions` error at the `tailscale up` step.
 
 **No TLS on the gRPC connection:** `bazel-remote` is exposed as plain `grpc://` (not `grpcs://`). TLS termination on the internal hostname is not configured. This is acceptable because the Tailscale tunnel already provides transport-layer encryption between the runner and the server; adding TLS on top would require a certificate for `docker-bazel-remote` with no additional security benefit.
 


### PR DESCRIPTION
## Summary

### Context

ADR 0017 incorrectly stated that the Tailscale OAuth client requires both `devices:core` and `keys:auth_keys` scopes. Only `keys:auth_keys` (read+write) is needed — `devices:core` is not required by `tailscale/github-action` v4.

### Changes

Removes the incorrect `devices:core` scope from the OAuth client requirements in ADR 0017, leaving only `keys:auth_keys` (read+write).

## Test Plan

- [x] Review ADR 0017 — only `keys:auth_keys` scope is mentioned for the OAuth client.