### PR TITLE
feat(sigil): Add modern-normalize support

### DIFF
--- a/packages/sigil/package.json
+++ b/packages/sigil/package.json
@@ -29,8 +29,8 @@
   "scripts": {
     "download-fonts": "node scripts/download-fonts.mjs",
     "postbuild": "node scripts/post-build.mjs",
-    "build": "sass src/index.scss ./dist/index.css --source-map",
-    "build-dev": "sass --watch src/index.scss ./dist/index.css --source-map",
+    "build": "sass --pkg-importer=node src/index.scss:./dist/index.css src/normalize.scss:./dist/normalize.css --source-map",
+    "build-dev": "sass --watch --pkg-importer=node src/index.scss:./dist/index.css src/normalize.scss:./dist/normalize.css --source-map",
     "lint-css": "stylelint \"src/**/*.scss\""
   },
   "devDependencies": {
@@ -38,6 +38,7 @@
     "@fontsource-variable/inconsolata": "catalog:",
     "@fontsource-variable/lora": "catalog:",
     "@fontsource/metamorphous": "catalog:",
+    "modern-normalize": "catalog:",
     "sass": "catalog:",
     "stylelint": "catalog:stylelint",
     "stylelint-config-clean-order": "catalog:stylelint",

--- a/packages/sigil/src/normalize.scss
+++ b/packages/sigil/src/normalize.scss
@@ -1,0 +1,1 @@
+@forward 'pkg:modern-normalize';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,6 +82,9 @@ catalogs:
     markdownlint-cli2:
       specifier: ~0.22.1
       version: 0.22.1
+    modern-normalize:
+      specifier: ~3.0.1
+      version: 3.0.1
     msw:
       specifier: ~2.14.6
       version: 2.14.6
@@ -500,6 +503,9 @@ importers:
       '@fontsource/metamorphous':
         specifier: 'catalog:'
         version: 5.2.8
+      modern-normalize:
+        specifier: 'catalog:'
+        version: 3.0.1
       sass:
         specifier: 'catalog:'
         version: 1.100.0
@@ -5818,6 +5824,10 @@ packages:
     resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
     engines: {node: '>= 18'}
 
+  modern-normalize@3.0.1:
+    resolution: {integrity: sha512-VqlMdYi59Uch6fnUPxnpijWUQe+TW6zeWCvyr6Mb7JibheHzSuAAoJi2c71ZwIaWKpECpGpYHoaaBp6rBRr+/g==}
+    engines: {node: '>=6'}
+
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
     engines: {node: '>=10'}
@@ -11041,9 +11051,9 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(@types/node@24.12.4)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@8.0.14(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(less@4.4.2)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+      vitest: 4.1.7(@types/node@24.12.4)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@8.0.14(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
     optionalDependencies:
-      '@vitest/browser': 4.1.7(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@8.0.14(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(less@4.4.2)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.7)
+      '@vitest/browser': 4.1.7(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@8.0.14(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.7)
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -11115,7 +11125,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(@types/node@24.12.4)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@8.0.14(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(less@4.4.2)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+      vitest: 4.1.7(@types/node@24.12.4)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@8.0.14(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -11760,7 +11770,7 @@ snapshots:
       normalize-path: 3.0.0
       schema-utils: 4.3.3
       serialize-javascript: 7.0.5
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
       webpack: 5.105.2(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.12)
 
   core-js-compat@3.49.0:
@@ -11816,7 +11826,7 @@ snapshots:
       postcss-modules-scope: 3.2.1(postcss@8.5.15)
       postcss-modules-values: 4.0.0(postcss@8.5.15)
       postcss-value-parser: 4.2.0
-      semver: 7.7.4
+      semver: 7.8.1
     optionalDependencies:
       webpack: 5.105.2(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.12)
 
@@ -13457,6 +13467,8 @@ snapshots:
     dependencies:
       minipass: 7.1.3
 
+  modern-normalize@3.0.1: {}
+
   mrmime@2.0.1: {}
 
   ms@2.0.0: {}
@@ -13920,7 +13932,7 @@ snapshots:
       cosmiconfig: 9.0.1(typescript@5.9.3)
       jiti: 2.7.0
       postcss: 8.5.12
-      semver: 7.7.4
+      semver: 7.8.1
     optionalDependencies:
       webpack: 5.105.2(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.12)
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -34,6 +34,7 @@ catalogs:
     husky: '~9.1.7'
     lint-staged: '~17.0.7'
     markdownlint-cli2: '~0.22.1'
+    modern-normalize: '~3.0.1'
     msw: '~2.14.6'
     rxjs: '~7.8.2'
     sass: '~1.100.0'


### PR DESCRIPTION
## Summary

### Context

Issue #112 is a prerequisite for the `normalize.css` entry point described in ADR-0016. Before that layer can be implemented, modern-normalize must be registered in the pnpm workspace catalog and available as a build-time devDependency in sigil so that Sass can resolve it via `pkg:` URLs.

### Changes

Adds `modern-normalize ~3.0.1` to the `default` pnpm catalog and wires it into `packages/sigil` as a devDependency. Creates `src/normalize.scss` as a thin `@forward 'pkg:modern-normalize'` wrapper, and updates the `build` and `build-dev` scripts to enable `--pkg-importer=node` (required for Sass `pkg:` URL resolution) and compile both entry points in a single invocation.

## Test Plan

- [x] Run `pnpm install` — confirm modern-normalize resolves without errors
- [x] Run `pnpm --filter @dnd-mapp/sigil build` — confirm both `dist/index.css` and `dist/normalize.css` are produced without Sass errors
- [x] Inspect `dist/normalize.css` — confirm it contains modern-normalize reset rules

Closes: #112