### PR TITLE
Wire ./normalize export in sigil and apply it in Realm

### DIFF
--- a/apps/realm/angular.json
+++ b/apps/realm/angular.json
@@ -26,7 +26,11 @@
                         "index": "./src/index.html",
                         "inlineStyleLanguage": "scss",
                         "outputPath": "dist",
-                        "styles": ["node_modules/@dnd-mapp/sigil/index.css", "./src/main.scss"],
+                        "styles": [
+                            "node_modules/@dnd-mapp/sigil/normalize.css",
+                            "node_modules/@dnd-mapp/sigil/index.css",
+                            "./src/main.scss"
+                        ],
                         "tsConfig": "./tsconfig.app.json"
                     },
                     "defaultConfiguration": "production",

--- a/apps/realm/src/main.scss
+++ b/apps/realm/src/main.scss
@@ -1,9 +1,3 @@
-*,
-*::before,
-*::after {
-    box-sizing: border-box;
-}
-
 html,
 body {
     height: 100dvh;

--- a/packages/sigil/package.json
+++ b/packages/sigil/package.json
@@ -11,6 +11,7 @@
   "license": "MIT",
   "exports": {
     ".": "./index.css",
+    "./normalize": "./normalize.css",
     "./primitives/*": {
       "sass": "./primitives/_*.scss"
     },


### PR DESCRIPTION
## Summary

### Context

The sigil package shipped `modern-normalize` support in #121, compiling `src/normalize.scss` to `dist/normalize.css` as part of the build pipeline. However, the package's `exports` map did not expose a `./normalize` entry, so consumers could not import `@dnd-mapp/sigil/normalize`. Realm also had a manual `box-sizing: border-box` reset that becomes redundant once normalize is applied.

### Changes

Added `"./normalize": "./normalize.css"` to the `exports` field in `packages/sigil/package.json`, wiring the already-built CSS file as a public export. In `apps/realm`, prepended `@dnd-mapp/sigil/normalize.css` to the global styles array in `angular.json` so browser normalization runs before design tokens and app styles. Removed the now-redundant `*, *::before, *::after { box-sizing: border-box }` block from `main.scss`, since `modern-normalize` already provides this exact rule.

## Test Plan

- [x] Build the sigil package (`pnpm --filter @dnd-mapp/sigil build`) and confirm `dist/package.json` includes `"./normalize": "./normalize.css"` in its exports.
- [x] Serve the Realm app and verify browser normalization styles are applied (consistent font sizing, no default body margin).
- [x] Confirm `box-sizing: border-box` still applies to all elements (provided by `modern-normalize`).

Closes: #114