### PR TITLE
feat(sigil): Add base element styles entry point

### DIFF
--- a/apps/realm/angular.json
+++ b/apps/realm/angular.json
@@ -28,6 +28,7 @@
                         "outputPath": "dist",
                         "styles": [
                             "node_modules/@dnd-mapp/sigil/normalize.css",
+                            "node_modules/@dnd-mapp/sigil/base.css",
                             "node_modules/@dnd-mapp/sigil/index.css",
                             "./src/main.scss"
                         ],

--- a/moon.yml
+++ b/moon.yml
@@ -9,6 +9,8 @@ tasks:
         command: 'pnpm playwright-install'
         inputs:
             - 'package.json'
+        options:
+            cache: false
 
     format-check:
         command: 'pnpm format-check'

--- a/packages/sigil/package.json
+++ b/packages/sigil/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": "./index.css",
     "./normalize": "./normalize.css",
+    "./base": "./base.css",
     "./primitives/*": {
       "sass": "./primitives/_*.scss"
     },
@@ -30,8 +31,8 @@
   "scripts": {
     "download-fonts": "node scripts/download-fonts.mjs",
     "postbuild": "node scripts/post-build.mjs",
-    "build": "sass --pkg-importer=node src/index.scss:./dist/index.css src/normalize.scss:./dist/normalize.css --source-map",
-    "build-dev": "sass --watch --pkg-importer=node src/index.scss:./dist/index.css src/normalize.scss:./dist/normalize.css --source-map",
+    "build": "sass --pkg-importer=node src/index.scss:./dist/index.css src/normalize.scss:./dist/normalize.css src/base.scss:./dist/base.css --source-map",
+    "build-dev": "sass --watch --pkg-importer=node src/index.scss:./dist/index.css src/normalize.scss:./dist/normalize.css src/base.scss:./dist/base.css --source-map",
     "lint-css": "stylelint \"src/**/*.scss\""
   },
   "devDependencies": {

--- a/packages/sigil/src/base.scss
+++ b/packages/sigil/src/base.scss
@@ -1,0 +1,73 @@
+@forward 'semantics/color';
+@forward 'semantics/typography';
+
+body {
+    font-family: var(--font-body);
+    font-size: var(--typography-size-sm);
+    line-height: var(--typography-line-height-normal);
+    color: var(--color-text-primary);
+
+    background-color: var(--color-surface-default);
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+    font-family: var(--font-heading);
+}
+
+h1 {
+    font-size: var(--typography-size-4xl);
+    font-weight: var(--typography-weight-bold);
+    line-height: var(--typography-line-height-tight);
+}
+
+h2 {
+    font-size: var(--typography-size-3xl);
+    font-weight: var(--typography-weight-bold);
+    line-height: var(--typography-line-height-tight);
+}
+
+h3 {
+    font-size: var(--typography-size-2xl);
+    font-weight: var(--typography-weight-semibold);
+    line-height: var(--typography-line-height-snug);
+}
+
+h4 {
+    font-size: var(--typography-size-xl);
+    font-weight: var(--typography-weight-semibold);
+    line-height: var(--typography-line-height-snug);
+}
+
+h5 {
+    font-size: var(--typography-size-lg);
+    font-weight: var(--typography-weight-medium);
+    line-height: var(--typography-line-height-snug);
+}
+
+h6 {
+    font-size: var(--typography-size-md);
+    font-weight: var(--typography-weight-medium);
+    line-height: var(--typography-line-height-normal);
+}
+
+code,
+kbd,
+samp {
+    font-family: var(--font-mono);
+}
+
+pre {
+    font-family: var(--font-mono);
+    font-size: var(--typography-size-xs);
+}
+
+hr {
+    border-color: var(--color-border-default);
+    border-style: solid;
+    border-width: 1px 0 0;
+}


### PR DESCRIPTION
## Summary

### Context

ADR 0016 specifies that Sigil ships three opt-in CSS entry points: `normalize.css` (cross-browser reset), `index.css` (design tokens), and `base.css` (opinionated element defaults). The first two already exist; this PR delivers the third. Without `base.css`, consumers wanting Sigil's typographic and color defaults applied to native HTML elements have no opt-in mechanism.

### Changes

Adds `packages/sigil/src/base.scss` which forwards the semantic color and typography partials (making `base.css` self-contained without requiring `index.css`) and defines element rules for `body`, `h1`–`h6`, `code`/`kbd`/`samp`, `pre`, and `hr` using semantic CSS custom properties. Wires `./base` into the sigil package exports and build scripts so `dist/base.css` is produced on every build. Adds `@dnd-mapp/sigil/base.css` to Realm's global styles array, slotted between `normalize.css` and `index.css`.

## Breaking Changes

None.

## Test Plan

- [x] Run `pnpm --filter @dnd-mapp/sigil build` and confirm `dist/base.css` is generated containing `:root` theme variable blocks followed by all specified element rules.
- [x] Run `pnpm --filter @dnd-mapp/sigil lint-css` and confirm zero errors and warnings.
- [x] Run the Realm app and verify body background colour, text colour, font family, and heading styles are applied from `base.css`.
- [x] Confirm `base.css` is self-contained: import it without `index.css` and verify the `:root` token declarations are present in the output.

Closes: #116