### PR TITLE
feat(realm): Serve dev server on port 4000

### DIFF
--- a/apps/realm/angular.json
+++ b/apps/realm/angular.json
@@ -63,7 +63,8 @@
                 "serve": {
                     "builder": "@angular/build:dev-server",
                     "options": {
-                        "buildTarget": "realm:build:development"
+                        "buildTarget": "realm:build:development",
+                        "port": 4000
                     }
                 },
                 "lint": {

--- a/e2e/realm/playwright.config.ts
+++ b/e2e/realm/playwright.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
     retries: isCI ? 2 : 0,
     reporter: [['html', { outputFolder: '../../reports/e2e/realm/html' }], ...(isCI ? [['github'] as const] : [])],
     use: {
-        baseURL: 'http://localhost:4200',
+        baseURL: 'http://localhost:4000',
         trace: 'on-first-retry',
     },
     projects: [
@@ -21,7 +21,7 @@ export default defineConfig({
     ],
     webServer: {
         command: 'pnpm --filter @dnd-mapp/realm start',
-        url: 'http://localhost:4200',
+        url: 'http://localhost:4000',
         reuseExistingServer: !isCI,
     },
     ...(isCI ? { workers: 1 } : {}),


### PR DESCRIPTION
## Summary

### Context

The Angular dev server was defaulting to port 4200, while the Docker image's nginx exposes Realm on host port 4000. Aligning the local dev-server port with the Docker port keeps both environments consistent and avoids confusion when switching between local and containerised runs.

### Changes

Added `"port": 4000` to the `serve.options` block in `apps/realm/angular.json` so `ng serve` binds to port 4000. Updated the Playwright e2e config's `baseURL` and `webServer.url` from `http://localhost:4200` to `http://localhost:4000` to match.

## Test Plan

- [x] Run `pnpm --filter @dnd-mapp/realm start` and confirm the dev server starts on port 4000
- [x] Run the Playwright e2e suite and confirm tests discover and target the server on port 4000

Closes: #102