### PR TITLE
Add Docker bake file for multi-platform Realm builds

### DIFF
--- a/.docker/bake.hcl
+++ b/.docker/bake.hcl
@@ -1,0 +1,31 @@
+variable "TAGS" {
+  default = ["latest"]
+  type    = list(string)
+}
+
+# docker/metadata-action populates this at CI time via its bake-file fragment.
+# It injects dynamic OCI labels (created, revision, version) and extra tags.
+target "docker-metadata-action" {}
+
+# Shared settings inherited by every image target.
+target "_common" {
+  platforms  = ["linux/amd64", "linux/arm64"]
+  provenance = true
+  sbom       = true
+}
+
+target "realm" {
+  inherits   = ["_common", "docker-metadata-action"]
+  dockerfile = ".docker/realm/Dockerfile"
+  context    = "."
+  tags       = [for tag in TAGS : "dndmapp/realm:${tag}"]
+  cache-from = ["type=registry,ref=dndmapp/realm:buildcache"]
+  cache-to   = ["type=registry,ref=dndmapp/realm:buildcache,mode=max"]
+  labels     = {
+    "org.opencontainers.image.title"       = "Realm"
+    "org.opencontainers.image.description" = "Angular SPA for D&D Mapp, served by nginx"
+    "org.opencontainers.image.url"         = "https://hub.docker.com/r/dndmapp/realm"
+    "org.opencontainers.image.source"      = "https://github.com/dnd-mapp/dma-platform"
+    "org.opencontainers.image.licenses"    = "MIT"
+  }
+}

--- a/.docker/realm/Dockerfile
+++ b/.docker/realm/Dockerfile
@@ -1,5 +1,8 @@
 # ── Build stage ────────────────────────────────────────────────────────────────
-FROM node:24.16.0-alpine3.23 AS build
+FROM --platform="$BUILDPLATFORM" node:24.16.0-alpine3.23 AS build
+
+ENV HUSKY="0" \
+    CI="true"
 
 WORKDIR /app
 
@@ -14,7 +17,8 @@ COPY packages/eslint-config/package.json      ./packages/eslint-config/
 COPY packages/sigil/package.json              ./packages/sigil/
 COPY packages/stylelint-config/package.json   ./packages/stylelint-config/
 
-RUN pnpm install --frozen-lockfile
+RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store \
+    pnpm install
 
 # Source — only after install so the above layer stays cached
 COPY . .

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,11 @@ updates:
       schedule:
           interval: weekly
 
+    - package-ecosystem: docker
+      directory: /.docker/realm
+      schedule:
+          interval: weekly
+
     - package-ecosystem: npm
       directory: /
       schedule:
@@ -16,6 +21,7 @@ updates:
                   - '@angular-eslint/*'
                   - 'angular-eslint'
                   - '@ngrx/*'
+                  - 'ng-packagr'
           eslint:
               patterns:
                   - 'eslint'
@@ -31,11 +37,31 @@ updates:
                   - '@playwright/*'
                   - 'vitest'
                   - '@vitest/*'
+                  - 'msw'
           tooling:
               patterns:
                   - '@commitlint/*'
+                  - '@moonrepo/*'
                   - 'husky'
                   - 'lint-staged'
                   - 'markdownlint*'
                   - 'prettier'
                   - 'prettier-*'
+                  - 'sass'
+                  - 'vite'
+                  - 'vite-*'
+          typescript:
+              patterns:
+                  - 'typescript'
+                  - '@types/*'
+                  - 'rxjs'
+                  - 'tslib'
+          storybook:
+              patterns:
+                  - 'storybook'
+                  - '@storybook/*'
+          fonts:
+              patterns:
+                  - '@fontsource/*'
+                  - '@fontsource-variable/*'
+                  - 'modern-normalize'


### PR DESCRIPTION
## Summary

### Context

Issue #104 is the final task in story #98 ("Create production Docker image for Realm"). The Dockerfile, nginx configs, and port configuration were already in place from issues #101–#103. What was missing was a `docker buildx bake` definition to drive reproducible multi-platform CI/CD builds with provenance attestations and a registry-backed layer cache.

### Changes

Adds `.docker/bake.hcl` with a `realm` target that builds for `linux/amd64` and `linux/arm64`. A `_common` base target holds shared settings (platforms, provenance, SBOM) to be inherited by future image targets, and an empty `docker-metadata-action` target enables dynamic OCI label and tag injection from the CI metadata action. The `TAGS` variable is a list of tag suffixes so the same variable can be reused across multiple targets as the repo grows.

The Dockerfile gains three improvements: the build stage is pinned to the host platform via `--platform=$BUILDPLATFORM` for efficient cross-compilation, `HUSKY=0` and `CI=true` are set to suppress git hooks and signal CI mode, and a BuildKit cache mount on the pnpm store avoids re-downloading packages on repeated builds.

Dependabot is extended with a new `docker` ecosystem entry for `.docker/realm` and several new/extended npm groups (`typescript`, `storybook`, `fonts`) to ensure all workspace dependencies receive automated updates.

## Test Plan

- [ ] Run `docker buildx bake --file .docker/bake.hcl realm --print` and confirm the resolved JSON shows `platforms: ["linux/amd64", "linux/arm64"]`, tags `["dndmapp/realm:latest"]`, `provenance: true`, `sbom: true`, and all five static OCI labels.

Closes: #104