### PR TITLE
docs(realm): add Docker Hub README

### DIFF
--- a/.docker/realm/README.md
+++ b/.docker/realm/README.md
@@ -1,0 +1,74 @@
+# dndmapp/realm
+
+Angular SPA for D&D Mapp, served by nginx on port 4000.
+
+## Tags
+
+| Tag          | Description                                                   |
+|--------------|---------------------------------------------------------------|
+| `next`       | Latest build from `main` — use this for deployments           |
+| `pr-{N}`     | Ephemeral build for PR #N — CI-only, do not use in production |
+| `buildcache` | Internal BuildKit cache layer — do not pull                   |
+
+## Configuration
+
+Runtime configuration is supplied by mounting a `config.json` file into the container:
+
+```text
+/usr/share/nginx/html/config.json
+```
+
+### Schema
+
+| Key | Type | Required | Description                                                                            |
+|-----|------|----------|----------------------------------------------------------------------------------------|
+| —   | —    | —        | No configuration keys yet — this table will grow as backend services are containerised |
+
+Minimal example:
+
+```json
+{}
+```
+
+## Quick start
+
+> [!NOTE]
+> Realm requires Gatekeeper and other companion services to function. A minimal `{}` config is enough to serve the SPA, but authentication and API calls will fail without them.
+
+**docker run:**
+
+```sh
+docker run -p 4000:4000 \
+  --name realm \
+  --restart unless-stopped \
+  -v ./config.json:/usr/share/nginx/html/config.json:ro \
+  dndmapp/realm:next
+```
+
+**Compose snippet (Realm only):**
+
+```yaml
+services:
+  realm:
+    image: dndmapp/realm:next
+    container_name: realm
+    restart: unless-stopped
+    ports:
+      - "4000:4000"
+    volumes:
+      - ./config.json:/usr/share/nginx/html/config.json:ro
+```
+
+## Building from source
+
+Prerequisites: Docker with BuildKit enabled, repository cloned.
+
+```sh
+docker buildx bake -f .docker/bake.hcl realm
+```
+
+The bake target builds for `linux/amd64` and `linux/arm64` by default. To restrict to a single platform for local development:
+
+```sh
+docker buildx bake -f .docker/bake.hcl realm --set realm.platforms=linux/amd64
+```


### PR DESCRIPTION
## Summary

### Context

Docker Hub is where self-hosters and the internal team pull the `dndmapp/realm` image. Without a README, users have no guidance on which tag to use, how to supply runtime configuration, or how to run the container.

### Changes

Adds `.docker/realm/README.md` — the Docker Hub README for the `dndmapp/realm` image. It covers the tags table (`next` for deployments, `pr-{N}` for CI-only ephemeral builds, `buildcache` as an internal cache layer), the runtime configuration mount path with an empty schema placeholder, quick-start `docker run` and Compose examples with `container_name` and `restart` settings, and a building-from-source section using `docker buildx bake`.

## Test Plan

- [x] Review the rendered README on Docker Hub after merging to confirm formatting is correct.
- [x] Confirm the `docker run` command works against a locally built image.
- [x] Confirm `docker buildx bake -f .docker/bake.hcl realm --set realm.platforms=linux/amd64` builds successfully.

Closes: #134