### PR TITLE
ci(pull-request): Add realm Docker build job

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,6 +2,11 @@ name: Pull Request
 
 on:
     pull_request:
+        types:
+            - opened
+            - synchronize
+            - reopened
+            - closed
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
@@ -12,6 +17,8 @@ jobs:
         name: CI
         runs-on: ubuntu-22.04
         timeout-minutes: 5
+        outputs:
+            realm_build_affected: ${{ steps.affected.outputs.realm_build_affected }}
         permissions:
             contents: read
             code-quality: write
@@ -24,6 +31,15 @@ jobs:
 
             - name: Setup workspace
               uses: ./.github/actions/setup-workspace
+
+            - name: Detect affected realm:build
+              id: affected
+              shell: bash
+              run: |
+                  RESULT=$(pnpm exec moon query tasks --affected --project realm --id build \
+                    | jq -r 'if (.tasks | keys | length) > 0 then "true" else "false" end')
+
+                  echo "realm_build_affected=${RESULT}" >> "$GITHUB_OUTPUT"
 
             - name: Connect to Tailscale
               uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4.1.2
@@ -60,3 +76,46 @@ jobs:
                   file: packages/arcane-ui/coverage/cobertura-coverage.xml
                   language: javascript
                   label: arcane-ui
+
+    docker:
+        name: Docker
+        needs: ci
+        if: needs.ci.outputs.realm_build_affected == 'true' && github.event.action != 'closed'
+        runs-on: ubuntu-22.04
+        timeout-minutes: 20
+        permissions:
+            contents: read
+        steps:
+            - name: Checkout
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+            - name: Docker metadata
+              id: meta
+              uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
+              with:
+                  images: dndmapp/realm
+                  tags: |
+                      type=ref,event=pr
+                  bake-target: docker-metadata-action
+
+            - name: Log in to Docker Hub
+              uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+              with:
+                  username: ${{ secrets.DOCKERHUB_USERNAME }}
+                  password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+            - name: Build and push
+              uses: docker/bake-action@6614cfa25eff9a0b2b2697efb0b6159e7680d584 # v7.2.0
+              with:
+                  files: |
+                      .docker/bake.hcl
+                      ${{ steps.meta.outputs.bake-file }}
+                  source: .
+                  targets: realm
+                  push: true


### PR DESCRIPTION
## Summary

### Context

The PR workflow had no Docker build step, leaving no way to pull and test the exact realm image produced by a PR before it merges.

### Changes

Extends `.github/workflows/pull-request.yml` with a `docker` job that builds and pushes `dndmapp/realm:pr-{N}` to Docker Hub whenever `realm:build` is affected by the PR's changes. Specifically: adds `closed` to the PR event types; adds a `Detect affected realm:build` step to the `ci` job (using `moon query tasks`) that exposes the result as a job output; and adds a conditional `docker` job that sets up QEMU and Buildx, injects OCI labels and the `pr-N` tag via `docker/metadata-action` into the existing bake-file stub, and calls `docker/bake-action` to perform the multi-platform build and push. The job is skipped when `realm:build` is unaffected or when the event is `closed`.

## Test Plan

- [ ] Open a PR modifying `apps/realm/src/**` and confirm the `docker` job runs and `dndmapp/realm:pr-{N}` appears on Docker Hub
- [ ] Open a PR modifying only unrelated files and confirm the `docker` job is skipped
- [ ] Merge or close a PR and confirm the `docker` job is skipped on the `closed` event

Refs: #105