### PR TITLE
ci(sync-dockerhub-readme): Sync DockerHub README

### DIFF
--- a/.github/workflows/sync-dockerhub-readme.yml
+++ b/.github/workflows/sync-dockerhub-readme.yml
@@ -1,0 +1,32 @@
+name: Sync DockerHub README
+
+on:
+    push:
+        branches:
+            - main
+        paths:
+            - '.docker/**/README.md'
+    workflow_dispatch:
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    sync:
+        name: Sync DockerHub README
+        runs-on: ubuntu-22.04
+        timeout-minutes: 5
+        permissions:
+            contents: read
+        steps:
+            - name: Checkout
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+            - name: Sync realm README
+              uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5.0.0
+              with:
+                  username: ${{ secrets.DOCKERHUB_USERNAME }}
+                  password: ${{ secrets.DOCKERHUB_TOKEN }}
+                  repository: dndmapp/realm
+                  readme-filepath: .docker/realm/README.md


### PR DESCRIPTION
## Summary

### Context

`.docker/realm/README.md` documents the `dndmapp/realm` Docker image on Docker Hub, but changes to it were not automatically reflected there — a manual update was required each time the file changed.

### Changes

Adds `.github/workflows/sync-dockerhub-readme.yml`, a new CI workflow that uses `peter-evans/dockerhub-description@v5.0.0` (SHA-pinned per repo convention) to push `.docker/realm/README.md` to the `dndmapp/realm` Docker Hub repository on every merge to `main` that touches a `.docker/**/README.md` file. A `workflow_dispatch` trigger is also included for first-run and manual recovery. Credentials (`DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN`) were established by #105 — no new secrets are required. To support a future service, add one step per image to the `sync` job.

## Test Plan

- [x] After merge, trigger manually via `gh workflow run sync-dockerhub-readme.yml` and confirm the run completes green under **Actions → Sync DockerHub README**
- [x] Verify the updated README content appears on the `dndmapp/realm` Docker Hub page
- [x] Confirm the path filter works: a `main` commit touching `.docker/realm/README.md` should trigger the workflow

Closes: #135