### PR TITLE
ci(pull-request): Add docker-cleanup job

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -126,6 +126,7 @@ jobs:
         if: needs.ci.outputs.realm_build_affected == 'true' && github.event.action == 'closed' && !github.event.pull_request.merged
         runs-on: ubuntu-22.04
         timeout-minutes: 5
+        permissions: {}
         steps:
             - name: Delete PR image tag from Docker Hub
               shell: bash

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -119,3 +119,41 @@ jobs:
                   source: .
                   targets: realm
                   push: true
+
+    docker-cleanup:
+        name: Docker cleanup
+        needs: ci
+        if: needs.ci.outputs.realm_build_affected == 'true' && github.event.action == 'closed' && !github.event.pull_request.merged
+        runs-on: ubuntu-22.04
+        timeout-minutes: 5
+        steps:
+            - name: Delete PR image tag from Docker Hub
+              shell: bash
+              env:
+                  DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+                  DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+                  PR_NUMBER: ${{ github.event.number }}
+              run: |
+                  TOKEN=$(jq -rn \
+                    --arg user "$DOCKERHUB_USERNAME" \
+                    --arg pass "$DOCKERHUB_TOKEN" \
+                    '{"username": $user, "password": $pass}' \
+                    | curl -fsSL -X POST \
+                        -H "Content-Type: application/json" \
+                        -d @- \
+                        "https://hub.docker.com/v2/users/login/" \
+                    | jq -r '.token')
+
+                  HTTP_STATUS=$(curl -o /dev/null -w "%{http_code}" -sL \
+                    -X DELETE \
+                    -H "Authorization: JWT ${TOKEN}" \
+                    "https://hub.docker.com/v2/repositories/dndmapp/realm/tags/pr-${PR_NUMBER}/")
+
+                  if [[ "$HTTP_STATUS" == "204" ]]; then
+                    echo "Tag pr-${PR_NUMBER} deleted."
+                  elif [[ "$HTTP_STATUS" == "404" ]]; then
+                    echo "Tag pr-${PR_NUMBER} not found — nothing to delete."
+                  else
+                    echo "Unexpected HTTP status: ${HTTP_STATUS}"
+                    exit 1
+                  fi


### PR DESCRIPTION
## Summary

### Context

PR image tags (`dndmapp/realm:pr-{N}`) pushed by the `docker` job were never cleaned up, leaving stale tags on Docker Hub after a PR was closed without being merged.

### Changes

Added a `docker-cleanup` job to the pull request workflow that deletes the `pr-{N}` image tag from Docker Hub when a PR is closed without being merged. The job reads the `realm_build_affected` output from the `ci` job so it only runs when the realm build was actually affected (and a PR image was therefore pushed). It authenticates via the Docker Hub v2 API using JWT, and treats a 404 response as a no-op to handle cases where the image was never successfully pushed.

## Test Plan

- [ ] Open a PR that touches the realm build; confirm `dndmapp/realm:pr-{N}` appears on Docker Hub after the `docker` job runs.
- [ ] Close the PR without merging; confirm the `docker-cleanup` job runs and the tag is removed from Docker Hub.
- [ ] Merge a PR that touches the realm build; confirm `docker-cleanup` is skipped.
- [ ] Close a PR that does not touch the realm build; confirm `docker-cleanup` is skipped.

Closes: #106