### PR TITLE
ci(push-main): Add docker-promote job

### DIFF
--- a/.github/actions/detect-affected-task/action.yml
+++ b/.github/actions/detect-affected-task/action.yml
@@ -1,0 +1,26 @@
+name: Detect Affected Moon Task
+description: Queries Moon to determine whether a given task is affected by recent changes.
+
+inputs:
+    project:
+        description: Moon project name (e.g. realm)
+        required: true
+    task:
+        description: Moon task id (e.g. build)
+        required: true
+
+outputs:
+    affected:
+        description: "'true' if the task is affected by recent changes, 'false' otherwise"
+        value: ${{ steps.query.outputs.affected }}
+
+runs:
+    using: composite
+    steps:
+        - name: Query Moon
+          id: query
+          shell: bash
+          run: |
+              RESULT=$(pnpm exec moon query tasks --affected --project ${{ inputs.project }} --id ${{ inputs.task }} \
+                | jq -r 'if (.tasks | keys | length) > 0 then "true" else "false" end')
+              echo "affected=${RESULT}" >> "$GITHUB_OUTPUT"

--- a/.github/actions/docker-promote-image/action.yml
+++ b/.github/actions/docker-promote-image/action.yml
@@ -1,0 +1,23 @@
+name: Promote Docker Image
+description: Re-tags a Docker image manifest to a new target reference using Buildx imagetools.
+
+inputs:
+    source:
+        description: Source image reference (e.g. dndmapp/realm:pr-123)
+        required: true
+    target:
+        description: Target image reference (e.g. dndmapp/realm:next)
+        required: true
+
+runs:
+    using: composite
+    steps:
+        - name: Set up Docker Buildx
+          uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+        - name: Promote image
+          shell: bash
+          run: |
+              docker buildx imagetools create \
+                -t ${{ inputs.target }} \
+                ${{ inputs.source }}

--- a/.github/actions/dockerhub-delete-tag/action.yml
+++ b/.github/actions/dockerhub-delete-tag/action.yml
@@ -1,0 +1,51 @@
+name: Delete Docker Hub Tag
+description: Deletes a tag from a Docker Hub repository.
+
+inputs:
+    username:
+        description: Docker Hub username
+        required: true
+    token:
+        description: Docker Hub access token
+        required: true
+    repository:
+        description: Docker Hub repository (e.g. dndmapp/realm)
+        required: true
+    tag:
+        description: Tag to delete (e.g. pr-123)
+        required: true
+
+runs:
+    using: composite
+    steps:
+        - name: Delete tag
+          shell: bash
+          env:
+              DOCKERHUB_USERNAME: ${{ inputs.username }}
+              DOCKERHUB_TOKEN: ${{ inputs.token }}
+              REPOSITORY: ${{ inputs.repository }}
+              TAG: ${{ inputs.tag }}
+          run: |
+              TOKEN=$(jq -rn \
+                --arg user "$DOCKERHUB_USERNAME" \
+                --arg pass "$DOCKERHUB_TOKEN" \
+                '{"username": $user, "password": $pass}' \
+                | curl -fsSL -X POST \
+                    -H "Content-Type: application/json" \
+                    -d @- \
+                    "https://hub.docker.com/v2/users/login/" \
+                | jq -r '.token')
+
+              HTTP_STATUS=$(curl -o /dev/null -w "%{http_code}" -sL \
+                -X DELETE \
+                -H "Authorization: JWT ${TOKEN}" \
+                "https://hub.docker.com/v2/repositories/${REPOSITORY}/tags/${TAG}/")
+
+              if [[ "$HTTP_STATUS" == "204" ]]; then
+                echo "Tag ${TAG} deleted."
+              elif [[ "$HTTP_STATUS" == "404" ]]; then
+                echo "Tag ${TAG} not found — nothing to delete."
+              else
+                echo "Unexpected HTTP status: ${HTTP_STATUS}"
+                exit 1
+              fi

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -18,7 +18,7 @@ jobs:
         runs-on: ubuntu-22.04
         timeout-minutes: 5
         outputs:
-            realm_build_affected: ${{ steps.affected.outputs.realm_build_affected }}
+            realm_build_affected: ${{ steps.affected.outputs.affected }}
         permissions:
             contents: read
             code-quality: write
@@ -34,12 +34,10 @@ jobs:
 
             - name: Detect affected realm:build
               id: affected
-              shell: bash
-              run: |
-                  RESULT=$(pnpm exec moon query tasks --affected --project realm --id build \
-                    | jq -r 'if (.tasks | keys | length) > 0 then "true" else "false" end')
-
-                  echo "realm_build_affected=${RESULT}" >> "$GITHUB_OUTPUT"
+              uses: ./.github/actions/detect-affected-task
+              with:
+                  project: realm
+                  task: build
 
             - name: Connect to Tailscale
               uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4.1.2
@@ -129,32 +127,9 @@ jobs:
         permissions: {}
         steps:
             - name: Delete PR image tag from Docker Hub
-              shell: bash
-              env:
-                  DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-                  DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-                  PR_NUMBER: ${{ github.event.number }}
-              run: |
-                  TOKEN=$(jq -rn \
-                    --arg user "$DOCKERHUB_USERNAME" \
-                    --arg pass "$DOCKERHUB_TOKEN" \
-                    '{"username": $user, "password": $pass}' \
-                    | curl -fsSL -X POST \
-                        -H "Content-Type: application/json" \
-                        -d @- \
-                        "https://hub.docker.com/v2/users/login/" \
-                    | jq -r '.token')
-
-                  HTTP_STATUS=$(curl -o /dev/null -w "%{http_code}" -sL \
-                    -X DELETE \
-                    -H "Authorization: JWT ${TOKEN}" \
-                    "https://hub.docker.com/v2/repositories/dndmapp/realm/tags/pr-${PR_NUMBER}/")
-
-                  if [[ "$HTTP_STATUS" == "204" ]]; then
-                    echo "Tag pr-${PR_NUMBER} deleted."
-                  elif [[ "$HTTP_STATUS" == "404" ]]; then
-                    echo "Tag pr-${PR_NUMBER} not found — nothing to delete."
-                  else
-                    echo "Unexpected HTTP status: ${HTTP_STATUS}"
-                    exit 1
-                  fi
+              uses: ./.github/actions/dockerhub-delete-tag
+              with:
+                  username: ${{ secrets.DOCKERHUB_USERNAME }}
+                  token: ${{ secrets.DOCKERHUB_TOKEN }}
+                  repository: dndmapp/realm
+                  tag: pr-${{ github.event.number }}

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -13,6 +13,8 @@ jobs:
         name: CI
         runs-on: ubuntu-22.04
         timeout-minutes: 5
+        outputs:
+            realm_build_affected: ${{ steps.affected.outputs.affected }}
         permissions:
             contents: read
             code-quality: write
@@ -24,6 +26,13 @@ jobs:
 
             - name: Setup workspace
               uses: ./.github/actions/setup-workspace
+
+            - name: Detect affected realm:build
+              id: affected
+              uses: ./.github/actions/detect-affected-task
+              with:
+                  project: realm
+                  task: build
 
             - name: Connect to Tailscale
               uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4.1.2
@@ -54,3 +63,44 @@ jobs:
                   file: packages/arcane-ui/coverage/cobertura-coverage.xml
                   language: javascript
                   label: arcane-ui
+
+    docker-promote:
+        name: Docker promote
+        needs: ci
+        if: needs.ci.outputs.realm_build_affected == 'true'
+        runs-on: ubuntu-22.04
+        timeout-minutes: 10
+        permissions:
+            contents: read
+            pull-requests: read
+        steps:
+            - name: Get merged PR number
+              id: pr
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              shell: bash
+              run: |
+                  PR_NUMBER=$(gh api \
+                    /repos/dnd-mapp/dma-platform/commits/${{ github.sha }}/pulls \
+                    --jq '.[0].number')
+                  echo "number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+
+            - name: Log in to Docker Hub
+              uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+              with:
+                  username: ${{ secrets.DOCKERHUB_USERNAME }}
+                  password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+            - name: Promote PR image to next
+              uses: ./.github/actions/docker-promote-image
+              with:
+                  source: dndmapp/realm:pr-${{ steps.pr.outputs.number }}
+                  target: dndmapp/realm:next
+
+            - name: Delete PR image tag from Docker Hub
+              uses: ./.github/actions/dockerhub-delete-tag
+              with:
+                  username: ${{ secrets.DOCKERHUB_USERNAME }}
+                  token: ${{ secrets.DOCKERHUB_TOKEN }}
+                  repository: dndmapp/realm
+                  tag: pr-${{ steps.pr.outputs.number }}


### PR DESCRIPTION
## Summary

### Context

When a PR that affects the realm Docker build is merged into main, the ephemeral `dndmapp/realm:pr-{N}` image was left on Docker Hub with no automated promotion or cleanup on the main-branch side.

### Changes

Adds a `docker-promote` job to `push-main.yml` that re-tags the merged PR image as `dndmapp/realm:next` and deletes the ephemeral `pr-{N}` tag. The job is conditional on Moon considering `realm:build` affected and recovers the PR number from the GitHub API.

Also extracts three reusable composite actions — `detect-affected-task`, `docker-promote-image`, and `dockerhub-delete-tag` — to eliminate the inline duplication between `pull-request.yml` and `push-main.yml`.

## Test Plan

- [ ] Merge a PR that touches `apps/realm/src/**` and observe the `push-main.yml` run — the `docker-promote` job should appear and pass
- [ ] Confirm `dndmapp/realm:next` is updated on Docker Hub after the run
- [ ] Confirm `dndmapp/realm:pr-{N}` is removed from Docker Hub
- [x] Merge a PR that does not touch realm and confirm the `docker-promote` job is skipped

Closes: #107