### PR TITLE
ci(e2e): Add Docker Compose E2E stack

### DIFF
--- a/.docker/Caddyfile
+++ b/.docker/Caddyfile
@@ -1,0 +1,4 @@
+localhost {
+    tls internal
+    reverse_proxy realm:4000
+}

--- a/.docker/compose.e2e.yml
+++ b/.docker/compose.e2e.yml
@@ -1,8 +1,10 @@
+name: realm-e2e
 services:
     realm:
         image: dndmapp/realm:pr-${PR_NUMBER}
+        container_name: realm
         healthcheck:
-            test: ['CMD', 'wget', '-q', '--spider', 'http://localhost:4000']
+            test: ['CMD-SHELL', 'wget -qO /dev/null http://127.0.0.1:4000']
             interval: 5s
             timeout: 3s
             retries: 5
@@ -10,6 +12,7 @@ services:
 
     proxy:
         image: caddy:2-alpine
+        container_name: proxy
         ports:
             - '443:443'
         volumes:

--- a/.docker/compose.e2e.yml
+++ b/.docker/compose.e2e.yml
@@ -1,0 +1,19 @@
+services:
+    realm:
+        image: dndmapp/realm:pr-${PR_NUMBER}
+        healthcheck:
+            test: ['CMD', 'wget', '-q', '--spider', 'http://localhost:4000']
+            interval: 5s
+            timeout: 3s
+            retries: 5
+            start_period: 5s
+
+    proxy:
+        image: caddy:2-alpine
+        ports:
+            - '443:443'
+        volumes:
+            - ./Caddyfile:/etc/caddy/Caddyfile:ro
+        depends_on:
+            realm:
+                condition: service_healthy

--- a/e2e/realm/README.md
+++ b/e2e/realm/README.md
@@ -10,10 +10,24 @@ See [Getting started](../../README.md#getting-started) in the root README.
 
 ## Running tests
 
+### Locally (dev server)
+
 ```sh
-pnpm --filter @dnd-mapp/realm-e2e test
+pnpm moon run realm-e2e:e2e-ci
 ```
 
-Playwright starts `apps/realm` automatically via its `webServer` config. Locally it reuses an already-running dev server if one is available; in CI it always starts a fresh one.
+Playwright starts `apps/realm` automatically via its `webServer` config and reuses an already-running dev server if one is available.
+
+### Against the Docker image (CI stack)
+
+Spin up the compose stack first, then run the tests with `CI=true` so Playwright targets `https://localhost` instead of the dev server:
+
+```sh
+PR_NUMBER=<n> docker compose -f .docker/compose.e2e.yml up -d
+CI=true pnpm moon run realm-e2e:e2e-ci
+docker compose -f .docker/compose.e2e.yml down
+```
+
+`PR_NUMBER` must match an image tag that exists in Docker Hub (`dndmapp/realm:pr-<n>`).
 
 HTML reports are written to `reports/e2e/realm/` and test artifacts (screenshots, traces) to `reports/e2e/realm/test-results/` in the repo root.

--- a/e2e/realm/playwright.config.ts
+++ b/e2e/realm/playwright.config.ts
@@ -10,8 +10,9 @@ export default defineConfig({
     retries: isCI ? 2 : 0,
     reporter: [['html', { outputFolder: './reports/html' }], ...(isCI ? [['github'] as const] : [])],
     use: {
-        baseURL: 'http://localhost:4000',
+        baseURL: isCI ? 'https://localhost' : 'http://localhost:4000',
         trace: 'on-first-retry',
+        ...(isCI ? { ignoreHTTPSErrors: true } : {}),
     },
     projects: [
         {
@@ -19,10 +20,13 @@ export default defineConfig({
             use: { ...devices['Desktop Chrome'] },
         },
     ],
-    webServer: {
-        command: 'pnpm --filter @dnd-mapp/realm start',
-        url: 'http://localhost:4000',
-        reuseExistingServer: !isCI,
-    },
-    ...(isCI ? { workers: 1 } : {}),
+    ...(isCI
+        ? { workers: 1 }
+        : {
+              webServer: {
+                  command: 'pnpm --filter @dnd-mapp/realm start',
+                  url: 'http://localhost:4000',
+                  reuseExistingServer: true,
+              },
+          }),
 });


### PR DESCRIPTION
## Summary

### Context

E2E tests need to run against the containerised Realm image in CI, not the Angular dev server. Realm's nginx container serves over plain HTTP (port 4000), but the app requires a secure context for cookies and browser APIs. A TLS-terminating proxy is needed to serve the app over HTTPS without mkcert or real certificates.

### Changes

Adds `.docker/compose.e2e.yml` with two services: `realm` (the `dndmapp/realm:pr-${PR_NUMBER}` nginx image, health-checked via `wget --spider`) and `proxy` (Caddy 2, `tls internal`, reverse-proxying to `realm:4000`, exposing port 443). The proxy only starts once the realm container is healthy. The Caddyfile is mounted read-only from `.docker/Caddyfile`.

Updates `e2e/realm/playwright.config.ts` to target `https://localhost` with `ignoreHTTPSErrors: true` in CI, and to omit the `webServer` dev-server launcher when `CI=true` — the compose stack provides the server instead.

## Test Plan

- [ ] Run `PR_NUMBER=123 docker compose -f .docker/compose.e2e.yml config` and confirm the realm image resolves to `dndmapp/realm:pr-123` and the Caddyfile volume path is correct.
- [ ] Confirm `npx tsc --noEmit` passes in `e2e/realm/`.
- [ ] Full end-to-end validation will follow in #109 when the E2E job is wired into `pull-request.yml`.

Closes: #108