### PR TITLE
ci(e2e-realm): Drop quality-gate deps from e2e-ci

### DIFF
--- a/e2e/realm/moon.yml
+++ b/e2e/realm/moon.yml
@@ -12,10 +12,8 @@ tasks:
         command: 'pnpm e2e-ci'
         deps:
             - 'root:playwright-install'
-            - 'realm:build'
-            - 'realm:lint-ts'
-            - 'realm:lint-css'
-            - 'realm:test-ci'
+        options:
+            runInCI: false
         inputs:
             - 'src/**/*.ts'
             - 'playwright.config.ts'


### PR DESCRIPTION
## Summary

### Context

The `e2e-ci` Moon task in `e2e/realm/moon.yml` had four quality-gate tasks (`realm:build`, `realm:lint-ts`, `realm:lint-css`, `realm:test-ci`) listed as `deps`. These ordering constraints belong at the CI pipeline level, not inside the task definition itself. Coupling them here slows down local reruns and creates redundant dependencies.

### Changes

Removed the four quality-gate deps from the `e2e-ci` task, keeping only `root:playwright-install`. Added `options: runInCI: false` so Moon does not auto-schedule the task when running in CI.

## Test Plan

- [ ] Verify `moon task e2e-realm:e2e-ci` lists only `root:playwright-install` as a dep and shows `runInCI: false` in options.
- [ ] Confirm CI pipeline still runs quality gates independently before triggering the e2e job.

Closes: #154