### PR TITLE
ci: Add e2e CI job with Docker Compose stack

### DIFF
--- a/.docker/Caddyfile
+++ b/.docker/Caddyfile
@@ -1,0 +1,4 @@
+localhost:4000 {
+    tls internal
+    reverse_proxy realm:4000
+}

--- a/.docker/compose.e2e.yml
+++ b/.docker/compose.e2e.yml
@@ -1,0 +1,22 @@
+name: realm-e2e
+services:
+    realm:
+        image: dndmapp/realm:pr-${PR_NUMBER}
+        container_name: realm
+        healthcheck:
+            test: ['CMD-SHELL', 'wget -qO /dev/null http://127.0.0.1:4000']
+            interval: 5s
+            timeout: 3s
+            retries: 5
+            start_period: 5s
+
+    proxy:
+        image: caddy:2-alpine
+        container_name: proxy
+        ports:
+            - '4000:4000'
+        volumes:
+            - ./Caddyfile:/etc/caddy/Caddyfile:ro
+        depends_on:
+            realm:
+                condition: service_healthy

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -80,7 +80,7 @@ jobs:
         needs: ci
         if: needs.ci.outputs.realm_build_affected == 'true' && github.event.action != 'closed'
         runs-on: ubuntu-22.04
-        timeout-minutes: 20
+        timeout-minutes: 10
         permissions:
             contents: read
         steps:
@@ -133,3 +133,42 @@ jobs:
                   token: ${{ secrets.DOCKERHUB_TOKEN }}
                   repository: dndmapp/realm
                   tag: pr-${{ github.event.number }}
+
+    e2e:
+        name: E2E
+        needs: [docker]
+        runs-on: ubuntu-22.04
+        timeout-minutes: 10
+        permissions:
+            contents: read
+        steps:
+            - name: Checkout
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+            - name: Setup workspace
+              uses: ./.github/actions/setup-workspace
+
+            - name: Connect to Tailscale
+              uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4.1.2
+              with:
+                  oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+                  oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+                  tags: tag:github-actions
+                  ping: docker-bazel-remote
+
+            - name: Start Realm container
+              env:
+                  PR_NUMBER: ${{ github.event.number }}
+              run: docker compose -f .docker/compose.e2e.yml up -d --wait
+
+            - name: Run E2E tests
+              env:
+                  MOON_REMOTE_HOST: grpc://docker-bazel-remote:9092
+              run: pnpm moon run realm-e2e:e2e-ci
+
+            - name: Upload E2E reports
+              if: failure()
+              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+              with:
+                  name: e2e-reports
+                  path: e2e/realm/reports/

--- a/e2e/realm/README.md
+++ b/e2e/realm/README.md
@@ -10,10 +10,24 @@ See [Getting started](../../README.md#getting-started) in the root README.
 
 ## Running tests
 
+### Locally (dev server)
+
 ```sh
-pnpm --filter @dnd-mapp/realm-e2e test
+pnpm moon run realm-e2e:e2e-ci
 ```
 
-Playwright starts `apps/realm` automatically via its `webServer` config. Locally it reuses an already-running dev server if one is available; in CI it always starts a fresh one.
+Playwright starts `apps/realm` automatically via its `webServer` config at `https://localhost:4000` and reuses an already-running dev server if one is available.
+
+### Against the Docker image (CI stack)
+
+Spin up the compose stack first, then run the tests with `CI=true` so Playwright targets `https://localhost:4000` via the Caddy proxy instead of the dev server:
+
+```sh
+PR_NUMBER=<n> docker compose -f .docker/compose.e2e.yml up -d
+CI=true pnpm moon run realm-e2e:e2e-ci
+docker compose -f .docker/compose.e2e.yml down
+```
+
+`PR_NUMBER` must match an image tag that exists in Docker Hub (`dndmapp/realm:pr-<n>`).
 
 HTML reports are written to `reports/e2e/realm/` and test artifacts (screenshots, traces) to `reports/e2e/realm/test-results/` in the repo root.

--- a/e2e/realm/playwright.config.ts
+++ b/e2e/realm/playwright.config.ts
@@ -10,8 +10,9 @@ export default defineConfig({
     retries: isCI ? 2 : 0,
     reporter: [['html', { outputFolder: './reports/html' }], ...(isCI ? [['github'] as const] : [])],
     use: {
-        baseURL: 'http://localhost:4000',
+        baseURL: 'https://localhost:4000',
         trace: 'on-first-retry',
+        ...(isCI ? { ignoreHTTPSErrors: true } : {}),
     },
     projects: [
         {
@@ -19,10 +20,13 @@ export default defineConfig({
             use: { ...devices['Desktop Chrome'] },
         },
     ],
-    webServer: {
-        command: 'pnpm --filter @dnd-mapp/realm start',
-        url: 'http://localhost:4000',
-        reuseExistingServer: !isCI,
-    },
-    ...(isCI ? { workers: 1 } : {}),
+    ...(isCI
+        ? { workers: 1 }
+        : {
+              webServer: {
+                  command: 'pnpm moon run realm:start',
+                  url: 'https://localhost:4000',
+                  reuseExistingServer: true,
+              },
+          }),
 });


### PR DESCRIPTION
## Summary

### Context

The PR workflow builds a `dndmapp/realm:pr-{N}` image when realm is affected but never validates it with end-to-end tests. E2E tests need to run against the containerised image rather than the dev server because the app requires a secure context (HTTPS) for cookies and browser APIs. A Caddy TLS-terminating proxy handles HTTPS since the realm nginx container serves plain HTTP internally.

### Changes

Adds `.docker/compose.e2e.yml` with two services: `realm` (the `dndmapp/realm:pr-${PR_NUMBER}` nginx image, health-checked via `wget --spider`) and `proxy` (Caddy 2, `tls internal`, reverse-proxying to `realm:4000`, exposing port 4000). The Caddyfile is mounted read-only from `.docker/Caddyfile`.

Updates `e2e/realm/playwright.config.ts` to target `https://localhost:4000` in all environments. In CI the `webServer` launcher is omitted (the compose stack provides the server) and `ignoreHTTPSErrors: true` is set for the self-signed Caddy cert. Locally, `webServer` uses `pnpm moon run realm:start` and reuses an existing server.

Adds an `e2e` job to `.github/workflows/pull-request.yml` (depends on `docker`) that starts the compose stack, runs `realm-e2e:e2e-ci` via Moon, and uploads Playwright reports on failure. Also reduces the `docker` job timeout from 20 to 10 minutes.

Updates the `e2e/realm` README to document both the local dev-server and Docker CI stack run modes.

## Test Plan

- [ ] Open a PR touching `apps/realm/` — confirm `docker` builds `dndmapp/realm:pr-{N}` and `e2e` runs Playwright against `https://localhost:4000`
- [ ] Confirm the `e2e` job is green when tests pass
- [ ] Force a Playwright failure — confirm `e2e/realm/reports/` appears as a workflow artifact
- [ ] Open a PR that does not affect realm — confirm `docker` and `e2e` are both skipped

Refs: #108, #152 · Closes: #155