### PR TITLE
feat(arcane-ui): Add Storybook viteFinal base path

### DIFF
--- a/packages/arcane-ui/.storybook/main.ts
+++ b/packages/arcane-ui/.storybook/main.ts
@@ -11,6 +11,10 @@ const config: StorybookConfig = {
             },
         },
     },
+    viteFinal: (config) => ({
+        ...config,
+        base: process.env['STORYBOOK_BASE_URL'] ?? '/',
+    }),
 };
 
 export default config;

--- a/packages/arcane-ui/.storybook/main.ts
+++ b/packages/arcane-ui/.storybook/main.ts
@@ -1,6 +1,7 @@
 import type { StorybookConfig } from '@storybook/angular';
+import type { StorybookConfigVite } from '@storybook/builder-vite';
 
-const config: StorybookConfig = {
+const config: StorybookConfig & StorybookConfigVite = {
     stories: ['../**/*.mdx', '../**/*.stories.ts'],
     addons: [],
     framework: {


### PR DESCRIPTION
## Summary

### Context

When Storybook is built for GitHub Pages deployment, assets must be served from the `/dma-platform/` subpath rather than the root `/`. Without a configured base path, Vite resolves assets relative to `/`, causing them to 404 on the deployed Pages site.

### Changes

Added a `viteFinal` hook to `packages/arcane-ui/.storybook/main.ts` that sets Vite's `base` option from `process.env['STORYBOOK_BASE_URL']`, falling back to `'/'` when the variable is not set. This makes GitHub Pages builds use the correct subpath while local development is unaffected.

## Test Plan

- [x] Run `moon run arcane-ui:storybook-build` — build succeeds and assets reference `/`
- [x] Run `STORYBOOK_BASE_URL=/dma-platform/ moon run arcane-ui:storybook-build` — asset paths in `dist/storybook/index.html` start with `/dma-platform/`
- [x] Run `moon run arcane-ui:storybook-start` — local dev server starts normally

Closes: #147