### PR TITLE
feat(arcane-ui): Declare STORYBOOK_BASE_URL in storybook-build task

### DIFF
--- a/.run/arcane-ui-storybook-build.run.xml
+++ b/.run/arcane-ui-storybook-build.run.xml
@@ -1,0 +1,14 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="arcane-ui-storybook-build" type="js.build_tools.npm" folderName="packages/arcane-ui">
+    <package-json value="$PROJECT_DIR$/package.json" />
+    <command value="run" />
+    <scripts>
+      <script value="moon" />
+    </scripts>
+    <arguments value="run arcane-ui:storybook-build" />
+    <node-interpreter value="project" />
+    <envs />
+    <EXTENSION ID="com.github.l34130.mise.core.run.MiseRunConfigurationSettingsEditor" myConfigEnvironmentStrategy="use_project_settings" myMiseDirEnvCb="false" myMiseConfigEnvironmentTf="" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/arcane-ui-storybook-start.run.xml
+++ b/.run/arcane-ui-storybook-start.run.xml
@@ -1,0 +1,14 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="arcane-ui-storybook-start" type="js.build_tools.npm" folderName="packages/arcane-ui">
+    <package-json value="$PROJECT_DIR$/package.json" />
+    <command value="run" />
+    <scripts>
+      <script value="moon" />
+    </scripts>
+    <arguments value="run arcane-ui:storybook-start" />
+    <node-interpreter value="project" />
+    <envs />
+    <EXTENSION ID="com.github.l34130.mise.core.run.MiseRunConfigurationSettingsEditor" myConfigEnvironmentStrategy="use_project_settings" myMiseDirEnvCb="false" myMiseConfigEnvironmentTf="" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/packages/arcane-ui/moon.yml
+++ b/packages/arcane-ui/moon.yml
@@ -31,6 +31,8 @@ tasks:
 
     storybook-build:
         command: 'pnpm storybook-build'
+        env:
+            STORYBOOK_BASE_URL: '/'
         inputs:
             - '**/*.{ts,html,scss}'
             - '**/*.stories.ts'


### PR DESCRIPTION
## Summary

### Context

The `storybook-build` moon task consumes `STORYBOOK_BASE_URL` to set the Vite base path at build time, but the variable was not declared in the task definition. Moon uses declared env vars as part of its cache key — without the declaration, PR builds (which use `base=/`) and push-main builds (which use `base=/dma-platform/`) share the same cache entry, causing incorrect cache hits.

### Changes

Added an `env` block to the `storybook-build` task in `packages/arcane-ui/moon.yml` that declares `STORYBOOK_BASE_URL: '/'` as its default. This makes the variable part of moon's cache key, ensuring PR and push-main builds produce separate cache entries. Also added IDE run configurations for the `arcane-ui:storybook-build` and `arcane-ui:storybook-start` moon tasks.

## Test Plan

- [ ] `moon run arcane-ui:storybook-build` completes successfully with the default base path `/`
- [ ] CI: PR workflow and push-main workflow produce separate cache entries for `storybook-build`

Closes: #148