### PR TITLE
ci(push-main): Add Storybook artifact upload step

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -13,8 +13,11 @@ jobs:
         name: CI
         runs-on: ubuntu-22.04
         timeout-minutes: 5
+        env:
+            STORYBOOK_BASE_URL: /dma-platform/
         outputs:
             realm_build_affected: ${{ steps.affected.outputs.affected }}
+            arcane_ui_storybook_affected: ${{ steps.arcane_ui_storybook_affected.outputs.affected }}
         permissions:
             contents: read
             code-quality: write
@@ -33,6 +36,13 @@ jobs:
               with:
                   project: realm
                   task: build
+
+            - name: Detect affected arcane-ui:storybook-build
+              id: arcane_ui_storybook_affected
+              uses: ./.github/actions/detect-affected-task
+              with:
+                  project: arcane-ui
+                  task: storybook-build
 
             - name: Connect to Tailscale
               uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4.1.2
@@ -63,6 +73,12 @@ jobs:
                   file: packages/arcane-ui/coverage/cobertura-coverage.xml
                   language: javascript
                   label: arcane-ui
+
+            - name: Upload Storybook artifact
+              if: steps.arcane_ui_storybook_affected.outputs.affected == 'true'
+              uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+              with:
+                  path: packages/arcane-ui/dist/storybook
 
     docker-promote:
         name: Docker promote


### PR DESCRIPTION
## Summary

### Context

The `arcane-ui` package gained Storybook build support with a configurable `STORYBOOK_BASE_URL` in recent work, but the `push-main.yml` CI workflow had no mechanism to detect when the Storybook build was affected or to upload its output as a GitHub Pages artifact.

### Changes

Added three things to the `ci` job in `.github/workflows/push-main.yml`: a job-level `STORYBOOK_BASE_URL: /dma-platform/` env var so Moon overrides the task-level default when building for GitHub Pages; a `Detect affected arcane-ui:storybook-build` step (reusing the existing `detect-affected-task` composite action) whose result is exposed as the `arcane_ui_storybook_affected` job output; and an `Upload Storybook artifact` step (using `actions/upload-pages-artifact@v5.0.0`, pinned by SHA) that conditionally runs only when the Storybook build is affected, uploading `packages/arcane-ui/dist/storybook`.

## Test Plan

- [ ] Push a commit touching `packages/arcane-ui` and confirm the `Detect affected arcane-ui:storybook-build` step outputs `true` and the upload step runs.
- [ ] Push a commit that does not touch `packages/arcane-ui` and confirm the upload step is skipped.
- [ ] Verify the uploaded artifact appears in the GitHub Actions run summary.

Closes: #149