### PR TITLE
ci(push-main): Add missing checkout step

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -74,6 +74,9 @@ jobs:
             contents: read
             pull-requests: read
         steps:
+            - name: Checkout
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
             - name: Get merged PR number
               id: pr
               env:


### PR DESCRIPTION
## Summary

### Context

The `get-merged-pr-number` job in the push-main workflow was missing a repository checkout step. Without it, any subsequent steps that rely on repository contents or git history cannot function correctly.

### Changes

Added an `actions/checkout` step (pinned at v6.0.3) as the first step in the `get-merged-pr-number` job, immediately before the existing PR number lookup step.

## Test Plan

- [ ] Push a change to main and verify the push-main workflow completes successfully
- [ ] Confirm the `get-merged-pr-number` job no longer fails due to a missing checkout