### PR TITLE
docs: Add changelog and release workflow ADRs

### DIFF
--- a/docs/adr/0019-per-package-keep-a-changelog-with-manual-authoring.md
+++ b/docs/adr/0019-per-package-keep-a-changelog-with-manual-authoring.md
@@ -1,0 +1,19 @@
+# ADR 0019: Per-package Keep a Changelog with manual authoring
+
+- **Status:** Accepted
+- **Date:** 2026-06-06
+
+## Context
+
+As packages approach their first versioned releases, there is a need to communicate what changed between versions — both for consumers within the monorepo and for future maintainers. Each package (`realm`, `arcane-ui`, `sigil`, `eslint-config`, `stylelint-config`) has an independent version and release cadence (see ADR 0020), so changelogs must be maintained per package.
+
+Two automated approaches were considered and rejected:
+
+- **`git-cliff` generating from conventional commits** — the natural fit given the existing commitlint enforcement, and natively targets Keep a Changelog format. However, in this monorepo, path-based filtering is required to scope commits per package. `git-cliff`'s `--include-path` is a positive filter only; excluding commits that touch multiple packages simultaneously requires layering `--exclude-path` for every other package, and commits that affect a package through out-of-root files (CI workflows, root configs) fall outside the path boundary entirely. The configuration is fragile and grows with the monorepo.
+- **Changesets (`@changesets/cli`)** — developers write a separate changeset file per PR alongside the commit. Produces rich prose entries, but duplicates the communication already invested in conventional commit messages. Two parallel descriptions of the same change is overhead without clear benefit.
+
+## Decision
+
+Each package and app has a `CHANGELOG.md` in [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format. Entries are written manually by the developer as part of the PR that introduces the change. Updating the changelog is a convention enforced by code review, not by CI or pre-commit hooks — not every commit warrants a user-facing entry, and automated gates cannot make that judgment.
+
+The `[Unreleased]` section accumulates changes between releases. On release, it is promoted to a versioned entry by the release script (see ADR 0020). Each file maintains Keep a Changelog comparison links at the bottom, updated by the release script on each release.

--- a/docs/adr/0020-pr-based-monorepo-release-workflow.md
+++ b/docs/adr/0020-pr-based-monorepo-release-workflow.md
@@ -1,0 +1,35 @@
+# ADR 0020: PR-based monorepo release workflow
+
+- **Status:** Accepted
+- **Date:** 2026-06-06
+
+## Context
+
+Each package has an independent version and requires a repeatable process for cutting releases, creating git tags, publishing GitHub Releases, and — for `realm` — producing versioned Docker images. With five packages at independent cadences, an ad-hoc manual process is error-prone: version bumps, changelog promotion, tag creation, and release notes all need to happen in the right order and stay consistent.
+
+## Decision
+
+Releases are initiated via an interactive TypeScript release script (`packages/release-script`, compiled to `scripts/` at the repo root) invoked through a moon task. The script:
+
+1. Prompts the developer to select a package or app to release.
+2. Collects commits since the last tag for that package (filtered by the package's path) and suggests a next version: `0.1.0` for the first release (no prior tag), or a semver bump derived from conventional commit types for subsequent releases — `BREAKING CHANGE` or `!` → major, `feat` → minor, everything else → patch.
+3. The developer confirms or overrides the suggested version.
+4. The script bumps the `version` field in the package's `package.json`, promotes `[Unreleased]` in its `CHANGELOG.md` to the versioned entry with today's date, inserts a fresh empty `[Unreleased]` section, and updates the Keep a Changelog comparison links at the bottom of the file.
+5. Creates a branch `release/<project>-<version>` and opens a pull request targeting `main`.
+
+After the release PR is merged, a dedicated CI workflow (`release-merge`) triggers on `pull_request: closed` where the PR is merged and the source branch matches `release/**`. The workflow:
+
+- Extracts the package name and version from the branch name.
+- Creates the git tag `<name>@<version>` (e.g. `sigil@1.2.0`).
+- Parses the versioned section from the package's `CHANGELOG.md` and appends a comparison link (`https://github.com/dnd-mapp/dma-platform/compare/<name>@<prev>...<name>@<version>`) as the GitHub Release body.
+- Creates a GitHub Release. If the version string contains a `-` pre-release identifier, the release is marked as a pre-release.
+- For `realm` releases only: promotes `dndmapp/realm:next` to `dndmapp/realm:latest`, `dndmapp/realm:<major>`, `dndmapp/realm:<major>.<minor>`, and `dndmapp/realm:<version>` — extending the build-once promotion chain established in ADR 0014.
+
+**Tag format:** `<package-name>@<version>` (e.g. `sigil@1.2.0`, `realm@0.1.0`). The `@` separator is valid in git tags and is the conventional choice for JS/TS monorepos.
+
+## Consequences
+
+- Releases are always traceable to a merged PR, giving reviewers a gate before a tag is created.
+- The `release-script` package is itself subject to the same conventions: it has its own `CHANGELOG.md`, version, and is released via the same workflow.
+- Docker image promotion for `realm` happens in the release-merge workflow immediately on PR merge, before any subsequent PR can advance `:next` — eliminating the race condition that would exist if promotion were deferred to a separate tag-push trigger.
+- The release script must be kept up-to-date as new packages are added to the monorepo.


### PR DESCRIPTION
## Summary

### Context

The project is moving toward independent versioned releases for all packages and apps in the monorepo. Before implementation begins, the key design decisions needed to be captured as ADRs so future contributors understand the rationale — particularly why automated changelog generation (git-cliff) was considered and rejected, and why a PR-based release flow was chosen over direct tagging.

### Changes

Added two ADRs under `docs/adr/`:

- **ADR 0019** — documents the decision to use per-package Keep a Changelog format with manual authoring. Records why git-cliff was ruled out (path-scoping complexity in a monorepo, cross-cutting commit handling) and why Changesets was ruled out (redundant alongside enforced conventional commits).
- **ADR 0020** — documents the PR-based release workflow: an interactive release script creates a `release/<project>-<version>` branch and PR; on merge, CI creates the git tag, publishes a GitHub Release (body extracted from the CHANGELOG section), and for `realm` promotes `dndmapp/realm:next` to versioned Docker image tags. Also records the `<name>@<version>` tag format and version suggestion logic (0.1.0 for first releases, conventional commit analysis thereafter).

## Test Plan

- [x] Review ADR 0019 for accuracy against the decisions made in the grilling session
- [x] Review ADR 0020 for accuracy, paying particular attention to the realm Docker promotion chain and its consistency with ADR 0014

Closes: #164