### PR TITLE
docs(realm): Add CHANGELOG.md

### DIFF
--- a/apps/realm/CHANGELOG.md
+++ b/apps/realm/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Angular SPA scaffolded as the initial Realm application
+- Runtime configuration loaded from `/config.json` at bootstrap; `RealmConfig` interface allows typed access to environment-specific values
+- Sigil normalize and base styles applied as global CSS layers, establishing a consistent baseline and element defaults across the app
+- Sigil design tokens and `provideTheme()` registered in the app config, enabling the shared theme system
+- Development server configured on port 4000
+
+### Fixed
+
+- Root component test spec now correctly provides `provideZonelessChangeDetection()` and `provideRouter([])`, matching the production app configuration
+
+[Unreleased]: https://github.com/dnd-mapp/dma-platform/compare/realm@0.0.0...HEAD


### PR DESCRIPTION
## Summary

### Context

ADR 0019 established a per-package Keep a Changelog convention for this monorepo. `apps/realm` needed its own `CHANGELOG.md` to serve as the accumulation point for unreleased changes between versions.

### Changes

Adds `apps/realm/CHANGELOG.md` with the standard Keep a Changelog header, an `[Unreleased]` section populated from the commit history of the app (scaffolding, runtime config, Sigil styles and theme integration, dev port), and a comparison link anchored to `realm@0.0.0...HEAD` for use by the release script.

## Test Plan

- [ ] `apps/realm/CHANGELOG.md` exists and renders correctly as Markdown
- [ ] The comparison link at the bottom uses the `realm@0.0.0...HEAD` format

Closes: #168