### PR TITLE
docs(eslint-config): Add CHANGELOG.md

### DIFF
--- a/packages/eslint-config/CHANGELOG.md
+++ b/packages/eslint-config/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- `@dnd-mapp/eslint-config` package scaffolded with two entry points: the default (`.`) exposes a base config that applies `eslint/js` recommended rules to `**/*.{js,mjs,cjs}` files; the `./angular` entry point extends the base with `typescript-eslint` type-checked rules for TypeScript source files, Angular template recommended and accessibility rules for HTML templates, and `eslint-config-prettier` to disable formatting-conflicting rules
+- `moon.yml` task configuration for Moonrepo, exposing a `lint-ts` task backed by `pnpm lint-ts`; inputs are scoped to `src/**/*.mjs` and `eslint.config.mjs` so Moon's cache is correctly invalidated on source changes
+
+### Changed
+
+- Minimum peer dependency versions raised: `eslint` from `>=9.0.0` to `>=10.0.0`, `eslint-config-prettier` from `>=9.0.0` to `>=10.0.0`
+- Node.js engine requirement raised from `>=18.18.0` to `>=24.0.0` to match the monorepo's pinned toolchain
+- `lint` npm script renamed to `lint-ts` for consistency with other Moonrepo-managed packages
+- `devDependencies` migrated to pnpm catalog references (`catalog:eslint` and `catalog:`) per ADR 0013, delegating version pinning to the workspace-level catalog
+
+[Unreleased]: https://github.com/dnd-mapp/dma-platform/compare/eslint-config@0.0.0...HEAD


### PR DESCRIPTION
## Summary

### Context

The project is adding initial `CHANGELOG.md` files to all packages and apps as part of issue #165. `packages/eslint-config` was the last package without one.

### Changes

Added `packages/eslint-config/CHANGELOG.md` in Keep a Changelog format. The `[Unreleased]` section is pre-filled from the package's git history: the initial scaffolding of the base TypeScript/JavaScript config and the `./angular` entry point, the Node.js engine bump to `>=24.0.0`, peer dependency minimums raised to `eslint >=10.0.0` and `eslint-config-prettier >=10.0.0`, the `moon.yml` Moonrepo task, the `lint` → `lint-ts` script rename, and the migration to pnpm catalog references per ADR 0013. The comparison link uses the `eslint-config@0.0.0...HEAD` tag format.

## Test Plan

- [x] `packages/eslint-config/CHANGELOG.md` exists and renders correctly on GitHub
- [x] The `[Unreleased]` comparison link uses the `eslint-config@0.0.0...HEAD` tag format

Closes: #171