### PR TITLE
docs(stylelint-config): Add CHANGELOG.md

### DIFF
--- a/packages/stylelint-config/CHANGELOG.md
+++ b/packages/stylelint-config/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Shared Stylelint configuration extending `stylelint-config-standard-scss` and `stylelint-config-clean-order`, providing standard SCSS rules and clean property ordering out of the box
+- Angular `:host` and `:host-context` pseudo-class support via custom rule overrides, allowing linting of Angular component stylesheets without false positives on Angular-specific selectors
+
+[Unreleased]: https://github.com/dnd-mapp/dma-platform/compare/stylelint-config@0.0.0...HEAD


### PR DESCRIPTION
## Summary

### Context

`packages/stylelint-config` was the only package in the monorepo without a CHANGELOG.md. Every package needs one in Keep a Changelog format to support the release workflow.

### Changes

Added `packages/stylelint-config/CHANGELOG.md` with the standard Keep a Changelog header, a pre-filled `[Unreleased]` section documenting the initial shared Stylelint configuration and Angular `:host` / `:host-context` pseudo-class support, and a comparison link using the `stylelint-config@0.0.0...HEAD` tag format.

## Test Plan

- [x] `packages/stylelint-config/CHANGELOG.md` exists and follows Keep a Changelog format
- [x] The `[Unreleased]` section lists entries for the initial configuration and Angular pseudo-class support
- [x] The comparison link at the bottom uses `stylelint-config@0.0.0...HEAD`

Closes: #172