### PR TITLE
docs(changelog): Fix [Unreleased] link convention

### DIFF
--- a/apps/realm/CHANGELOG.md
+++ b/apps/realm/CHANGELOG.md
@@ -18,5 +18,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Root component test spec now correctly provides `provideZonelessChangeDetection()` and `provideRouter([])`, matching the production app configuration
-
-[Unreleased]: https://github.com/dnd-mapp/dma-platform/compare/realm@0.0.0...HEAD

--- a/docs/adr/0019-per-package-keep-a-changelog-with-manual-authoring.md
+++ b/docs/adr/0019-per-package-keep-a-changelog-with-manual-authoring.md
@@ -16,4 +16,7 @@ Two automated approaches were considered and rejected:
 
 Each package and app has a `CHANGELOG.md` in [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format. Entries are written manually by the developer as part of the PR that introduces the change. Updating the changelog is a convention enforced by code review, not by CI or pre-commit hooks — not every commit warrants a user-facing entry, and automated gates cannot make that judgment.
 
-The `[Unreleased]` section accumulates changes between releases. On release, it is promoted to a versioned entry by the release script (see ADR 0020). Each file maintains Keep a Changelog comparison links at the bottom, updated by the release script on each release.
+The `[Unreleased]` section accumulates changes between releases. On release, it is promoted to a versioned entry by the release script (see ADR 0020). Each file maintains Keep a Changelog reference links at the bottom, updated by the release script on each release:
+
+- Versioned entries (e.g. `[0.1.0]`) link to their GitHub Release page (`releases/tag/<package>@<version>`).
+- `[Unreleased]` links to `compare/<package>@<last-version>...HEAD`, showing all commits since the last release. Before any release exists, the `[Unreleased]` link is omitted entirely.

--- a/docs/adr/0020-pr-based-monorepo-release-workflow.md
+++ b/docs/adr/0020-pr-based-monorepo-release-workflow.md
@@ -14,14 +14,14 @@ Releases are initiated via an interactive TypeScript release script (`packages/r
 1. Prompts the developer to select a package or app to release.
 2. Collects commits since the last tag for that package (filtered by the package's path) and suggests a next version: `0.1.0` for the first release (no prior tag), or a semver bump derived from conventional commit types for subsequent releases — `BREAKING CHANGE` or `!` → major, `feat` → minor, everything else → patch.
 3. The developer confirms or overrides the suggested version.
-4. The script bumps the `version` field in the package's `package.json`, promotes `[Unreleased]` in its `CHANGELOG.md` to the versioned entry with today's date, inserts a fresh empty `[Unreleased]` section, and updates the Keep a Changelog comparison links at the bottom of the file.
+4. The script bumps the `version` field in the package's `package.json`, promotes `[Unreleased]` in its `CHANGELOG.md` to the versioned entry with today's date, inserts a fresh empty `[Unreleased]` section, and updates the Keep a Changelog reference links at the bottom of the file: the new versioned entry gets a `releases/tag/<package>@<version>` link; `[Unreleased]` gets a `compare/<package>@<version>...HEAD` link (see ADR 0019 for the full link convention).
 5. Creates a branch `release/<project>-<version>` and opens a pull request targeting `main`.
 
 After the release PR is merged, a dedicated CI workflow (`release-merge`) triggers on `pull_request: closed` where the PR is merged and the source branch matches `release/**`. The workflow:
 
 - Extracts the package name and version from the branch name.
 - Creates the git tag `<name>@<version>` (e.g. `sigil@1.2.0`).
-- Parses the versioned section from the package's `CHANGELOG.md` and appends a comparison link (`https://github.com/dnd-mapp/dma-platform/compare/<name>@<prev>...<name>@<version>`) as the GitHub Release body.
+- Parses the versioned section from the package's `CHANGELOG.md` and uses it as the GitHub Release body.
 - Creates a GitHub Release. If the version string contains a `-` pre-release identifier, the release is marked as a pre-release.
 - For `realm` releases only: promotes `dndmapp/realm:next` to `dndmapp/realm:latest`, `dndmapp/realm:<major>`, `dndmapp/realm:<major>.<minor>`, and `dndmapp/realm:<version>` — extending the build-once promotion chain established in ADR 0014.
 

--- a/packages/arcane-ui/CHANGELOG.md
+++ b/packages/arcane-ui/CHANGELOG.md
@@ -26,5 +26,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Cross-entry-point imports in the `config` entry point corrected to use the full package name so `ng-packagr` resolves entry-point boundaries correctly
 - `viteFinal` in the Storybook configuration typed via `StorybookConfigVite` to restore TypeScript narrowing after the Storybook 9 migration
-
-[Unreleased]: https://github.com/dnd-mapp/dma-platform/compare/arcane-ui@0.0.0...HEAD

--- a/packages/eslint-config/CHANGELOG.md
+++ b/packages/eslint-config/CHANGELOG.md
@@ -18,5 +18,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Node.js engine requirement raised from `>=18.18.0` to `>=24.0.0` to match the monorepo's pinned toolchain
 - `lint` npm script renamed to `lint-ts` for consistency with other Moonrepo-managed packages
 - `devDependencies` migrated to pnpm catalog references (`catalog:eslint` and `catalog:`) per ADR 0013, delegating version pinning to the workspace-level catalog
-
-[Unreleased]: https://github.com/dnd-mapp/dma-platform/compare/eslint-config@0.0.0...HEAD

--- a/packages/sigil/CHANGELOG.md
+++ b/packages/sigil/CHANGELOG.md
@@ -27,5 +27,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `build` and `build-dev` scripts extended to compile `normalize.scss` and `base.scss` alongside `index.scss`; `--pkg-importer=node` flag added to resolve `pkg:` imports (e.g. `pkg:modern-normalize`)
 - All `devDependencies` migrated to shared pnpm catalog references (ADR 0013)
 - Moon `dependsOn: [stylelint-config]` removed — dependency is now auto-detected from the pnpm workspace link in `package.json`
-
-[Unreleased]: https://github.com/dnd-mapp/dma-platform/compare/sigil@0.0.0...HEAD

--- a/packages/stylelint-config/CHANGELOG.md
+++ b/packages/stylelint-config/CHANGELOG.md
@@ -11,5 +11,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Shared Stylelint configuration extending `stylelint-config-standard-scss` and `stylelint-config-clean-order`, providing standard SCSS rules and clean property ordering out of the box
 - Angular `:host` and `:host-context` pseudo-class support via custom rule overrides, allowing linting of Angular component stylesheets without false positives on Angular-specific selectors
-
-[Unreleased]: https://github.com/dnd-mapp/dma-platform/compare/stylelint-config@0.0.0...HEAD


### PR DESCRIPTION
## Summary

### Context

The initial changelogs were created with a phantom `[Unreleased]` comparison link pointing to `<package>@0.0.0...HEAD` — a tag that does not exist and should not. The link technically resolved but had no valid left-hand side, making it misleading for any reader who clicked it.

### Changes

Removed the phantom `[Unreleased]` reference links from all five changelogs; the header is now a plain (unlinked) heading until the first release is cut, at which point the release script will add the appropriate link. Updated ADR 0019 to document the agreed two-tier link convention: versioned entries link to their GitHub Release page (`releases/tag/<package>@<version>`); `[Unreleased]` links to the compare diff since the last release (`compare/<package>@<version>...HEAD`); the link is omitted entirely before any release exists. Updated ADR 0020 to match: the release script writes `releases/tag` links for version entries and a `compare` link for `[Unreleased]`; the CI workflow uses the changelog section as-is for the GitHub Release body, relying on GitHub's native compare functionality instead of appending a redundant manual link.

## Test Plan

- [ ] Open each `CHANGELOG.md` and confirm `[Unreleased]` has no reference link at the bottom of the file.
- [ ] Read ADR 0019 and verify the two-tier link convention is described accurately.
- [ ] Read ADR 0020 and verify step 4 and the CI workflow section match the new convention.

Refs: #164