### PR TITLE
Clean up ADR numbering and document GraphQL mutation shape

### DIFF
--- a/docs/adr/0021-https-local-dev-with-mkcert.md
+++ b/docs/adr/0021-https-local-dev-with-mkcert.md
@@ -1,4 +1,4 @@
-# ADR 0007: HTTPS-only local dev for Realm via mkcert and custom hostname
+# ADR 0021: HTTPS-only local dev for Realm via mkcert and custom hostname
 
 - **Status:** Accepted
 - **Date:** 2026-05-30

--- a/docs/agents/issue-types.md
+++ b/docs/agents/issue-types.md
@@ -26,6 +26,8 @@ Org-level issue type: `Epic` (node ID: `IT_kwDODFcis84CBKdR`)
 | `P2`  | `IFSSO_kgDOBHIfOw` | Normal priority — planned and scheduled                     |
 | `P3`  | `IFSSO_kgDOBHIfPA` | Low priority — nice to have, no firm commitment             |
 
+> **GraphQL note — Priority:** Set via `updateIssueFieldValue` with `issueField: { fieldId: "IFSS_kgDOAopeGg", singleSelectOptionId: "<option_id>" }`. This applies to all Issue Types that carry the priority field.
+
 ### Statuses
 
 `Status` Project field (single-select, node ID: `PVTSSF_lADODFcis84BY-C4zhUADuc`):
@@ -157,6 +159,8 @@ Org-level issue type: `Bug` (node ID: `IT_kwDODFcis84CBK3a`)
 | `S2`  | `IFSSO_kgDOBHIscg` | Degraded experience; reasonable workaround available                  |
 | `S3`  | `IFSSO_kgDOBHIscw` | Cosmetic or minor issue; does not impact functionality                |
 
+> **GraphQL note — Severity:** Set via `updateIssueFieldValue` with `issueField: { fieldId: "IFSS_kgDOAoplog", singleSelectOptionId: "<option_id>" }`.
+
 ### Statuses
 
 `Status` Project field (single-select, node ID: `PVTSSF_lADODFcis84BY-C4zhUADuc`):
@@ -200,6 +204,8 @@ Org-level issue type: `Spike` (node ID: `IT_kwDODFcis84CBK-7`)
 | `parent`   | Project field (native) | `PVTF_lADODFcis84BY-C4zhUADu4` | Parent issue  | `Parent #<n>`                        |
 
 **Priority options:** see Epic section above.
+
+> **GraphQL note — Time box:** Set via `updateIssueFieldValue` with `issueField: { fieldId: "IFT_kgDOAopn2A", textValue: "<value>" }` (e.g. `"2d"`, `"1 week"`).
 
 ### Statuses
 


### PR DESCRIPTION
## Summary

### Context

Two housekeeping issues were identified during a review of the docs. The HTTPS local dev ADR (`0007-https-local-dev-with-mkcert.md`) was assigned number 0007, which was already taken by the Sigil design token ADR. Additionally, the agent docs for issue field mutations were incomplete — only Story Points documented the nested `issueField` input shape required by `updateIssueFieldValue`.

### Changes

- Renumbered the HTTPS local dev ADR from 0007 to 0021 to resolve the numbering conflict.
- Added GraphQL mutation shape notes for priority, severity, and time-box fields in `docs/agents/issue-types.md`, consistent with the existing Story Points note.

## Breaking Changes

N/A

## Test Plan

- [x] Verify `docs/adr/0021-https-local-dev-with-mkcert.md` exists and its heading reads "ADR 0021"
- [x] Verify no two files in `docs/adr/` share a numeric prefix
- [x] Verify `docs/agents/issue-types.md` contains GraphQL notes for priority, severity, and time-box