### PR TITLE
feat(release-script): Scaffold package

### DIFF
--- a/.docker/realm/Dockerfile
+++ b/.docker/realm/Dockerfile
@@ -14,6 +14,7 @@ COPY apps/realm/package.json                  ./apps/realm/
 COPY e2e/realm/package.json                   ./e2e/realm/
 COPY packages/arcane-ui/package.json          ./packages/arcane-ui/
 COPY packages/eslint-config/package.json      ./packages/eslint-config/
+COPY packages/release-script/package.json              ./packages/release-script/
 COPY packages/sigil/package.json              ./packages/sigil/
 COPY packages/stylelint-config/package.json   ./packages/stylelint-config/
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 
 **/.angular/
 **/dist/
+/out-tsc/
+/scripts/release/
 
 **/coverage/
 **/reports/

--- a/.moon/workspace.yml
+++ b/.moon/workspace.yml
@@ -3,6 +3,7 @@ $schema: 'https://moonrepo.dev/schemas/workspace.json'
 projects:
     realm: 'apps/realm'
     arcane-ui: 'packages/arcane-ui'
+    release-script: 'packages/release-script'
     sigil: 'packages/sigil'
     eslint-config: 'packages/eslint-config'
     stylelint-config: 'packages/stylelint-config'

--- a/README.md
+++ b/README.md
@@ -17,10 +17,13 @@ Monorepo for the D&D Mapp platform — libraries and applications powering chara
 
 ### Packages
 
-| Package                                                   | Description                                  |
-|:----------------------------------------------------------|:---------------------------------------------|
-| [eslint-config](packages/eslint-config/README.md)         | Shared ESLint flat config for TS and Angular |
-| [stylelint-config](packages/stylelint-config/README.md)   | Shared Stylelint config for SCSS and Angular |
+| Package                                                   | Description                                                                    |
+|:----------------------------------------------------------|:-------------------------------------------------------------------------------|
+| [arcane-ui](packages/arcane-ui/README.md)                 | Shared Angular component library built on sigil design tokens                  |
+| [eslint-config](packages/eslint-config/README.md)         | Shared ESLint flat config for TS and Angular                                   |
+| [release-script](packages/release-script/README.md)       | Interactive release script — bumps versions, promotes changelogs, opens PRs    |
+| [sigil](packages/sigil/README.md)                         | Design token library — colors, typography, and spacing as SCSS and CSS         |
+| [stylelint-config](packages/stylelint-config/README.md)   | Shared Stylelint config for SCSS and Angular                                   |
 
 ### End-to-end tests
 

--- a/moon.yml
+++ b/moon.yml
@@ -32,3 +32,10 @@ tasks:
         inputs:
             - '**/*.md'
             - '.markdownlint-cli2.json'
+
+    release:
+        command: 'node scripts/release/index.js'
+        deps:
+            - 'release-script:build'
+        options:
+            cache: false

--- a/packages/eslint-config/CHANGELOG.md
+++ b/packages/eslint-config/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `./node` entry point — TypeScript strict type-checked rules (`typescript-eslint` `strictTypeChecked` preset) with `eslint-config-prettier`, for use in Node.js and CLI packages
 - `@dnd-mapp/eslint-config` package scaffolded with two entry points: the default (`.`) exposes a base config that applies `eslint/js` recommended rules to `**/*.{js,mjs,cjs}` files; the `./angular` entry point extends the base with `typescript-eslint` type-checked rules for TypeScript source files, Angular template recommended and accessibility rules for HTML templates, and `eslint-config-prettier` to disable formatting-conflicting rules
 - `moon.yml` task configuration for Moonrepo, exposing a `lint-ts` task backed by `pnpm lint-ts`; inputs are scoped to `src/**/*.mjs` and `eslint.config.mjs` so Moon's cache is correctly invalidated on source changes
 

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -14,7 +14,8 @@
   "type": "module",
   "exports": {
     ".": "./src/index.mjs",
-    "./angular": "./src/angular.mjs"
+    "./angular": "./src/angular.mjs",
+    "./node": "./src/node.mjs"
   },
   "files": [
     "src"

--- a/packages/eslint-config/src/node.mjs
+++ b/packages/eslint-config/src/node.mjs
@@ -1,0 +1,10 @@
+import prettierConfig from 'eslint-config-prettier';
+import { defineConfig } from 'eslint/config';
+import tseslint from 'typescript-eslint';
+
+export default defineConfig([
+    {
+        files: ['**/*.ts'],
+        extends: [...tseslint.configs.strictTypeChecked, prettierConfig],
+    },
+]);

--- a/packages/release-script/CHANGELOG.md
+++ b/packages/release-script/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/packages/release-script/README.md
+++ b/packages/release-script/README.md
@@ -1,0 +1,39 @@
+# @dnd-mapp/release-script
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](../../LICENSE)
+[![node: >=24.0.0](https://img.shields.io/badge/node-%3E%3D24.0.0-339933?logo=nodedotjs&logoColor=white)](package.json)
+
+Interactive release script for the D&D Mapp monorepo. Handles version bumps, changelog promotion, and release PR creation for any package or app in the workspace.
+
+## Usage
+
+```sh
+moon run root:release
+```
+
+The script is compiled from TypeScript source to `scripts/release/` at the repo root and invoked through the `root:release` Moon task, which rebuilds the script automatically before running it.
+
+## Release flow
+
+1. **Select a package** — choose the package or app to release from a list of all workspace projects.
+2. **Pick a version** — commits since the last tag are collected (filtered to the package's path) and a next version is suggested:
+   - First release (no prior tag): `0.1.0`
+   - Subsequent releases: semver bump derived from conventional commit types — `BREAKING CHANGE` or `!` → major, `feat` → minor, everything else → patch
+3. **Confirm or override** — accept the suggestion or enter a version manually.
+4. **Apply changes** — the script updates the package's files:
+   - Bumps `version` in `package.json`
+   - Promotes `[Unreleased]` in `CHANGELOG.md` to a versioned entry with today's date
+   - Inserts a fresh empty `[Unreleased]` section above it
+   - Updates the Keep a Changelog reference links at the bottom of the file
+5. **Open a PR** — creates a branch `release/<project>-<version>` and opens a pull request targeting `main`.
+
+## After the PR merges
+
+A dedicated CI workflow (`release-merge`) takes over on merge:
+
+- Extracts the package name and version from the branch name
+- Creates a git tag `<name>@<version>` (e.g. `sigil@1.2.0`)
+- Parses the versioned section from `CHANGELOG.md` and creates a GitHub Release from it
+- For `realm` releases only: promotes the `dndmapp/realm:next` Docker image to the versioned tags
+
+See [ADR 0020](../../docs/adr/0020-pr-based-monorepo-release-workflow.md) for the full architecture.

--- a/packages/release-script/eslint.config.mjs
+++ b/packages/release-script/eslint.config.mjs
@@ -1,0 +1,15 @@
+import nodeConfig from '@dnd-mapp/eslint-config/node';
+
+export default [
+    { ignores: ['coverage/', 'reports/', 'node_modules/'] },
+    ...nodeConfig,
+    {
+        files: ['**/*.ts'],
+        languageOptions: {
+            parserOptions: {
+                projectService: true,
+                tsconfigRootDir: import.meta.dirname,
+            },
+        },
+    },
+];

--- a/packages/release-script/moon.yml
+++ b/packages/release-script/moon.yml
@@ -1,0 +1,35 @@
+$schema: 'https://moonrepo.dev/schemas/project.json'
+
+language: 'typescript'
+stack: 'unknown'
+layer: 'tool'
+
+tasks:
+    build:
+        command: 'pnpm build'
+        inputs:
+            - 'src/**/*.ts'
+            - 'tsconfig.json'
+            - '/tsconfig.base.json'
+        outputs:
+            - '/scripts/release/**'
+
+    lint-ts:
+        command: 'pnpm lint-ts'
+        inputs:
+            - 'src/**/*.ts'
+            - 'eslint.config.mjs'
+            - '/eslint.config.mjs'
+
+    test-ci:
+        command: 'pnpm test-ci'
+        inputs:
+            - 'src/**/*.ts'
+            - 'vitest.config.ts'
+        outputs:
+            - 'coverage/**'
+            - 'reports/**'
+
+    test:
+        command: 'pnpm test'
+        preset: 'server'

--- a/packages/release-script/package.json
+++ b/packages/release-script/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@dnd-mapp/release-script",
+  "version": "0.0.0",
+  "description": "Interactive release script for the D&D Mapp monorepo — bumps versions, promotes changelogs, and opens release PRs.",
+  "license": "MIT",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc --project tsconfig.build.json",
+    "test-ci": "vitest run",
+    "test": "vitest",
+    "lint-ts": "eslint ."
+  },
+  "engines": {
+    "node": ">=24.0.0"
+  },
+  "devDependencies": {
+    "@dnd-mapp/eslint-config": "workspace:*",
+    "@types/node": "catalog:",
+    "@vitest/coverage-v8": "catalog:vitest",
+    "@vitest/ui": "catalog:vitest",
+    "eslint": "catalog:eslint",
+    "eslint-config-prettier": "catalog:eslint",
+    "typescript": "catalog:",
+    "typescript-eslint": "catalog:eslint",
+    "vitest": "catalog:vitest"
+  }
+}

--- a/packages/release-script/src/index.ts
+++ b/packages/release-script/src/index.ts
@@ -1,0 +1,1 @@
+#!/usr/bin/env node

--- a/packages/release-script/tsconfig.build.json
+++ b/packages/release-script/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+    "extends": "./tsconfig.json",
+    "include": ["src/**/*.ts"],
+    "exclude": ["src/**/*.spec.ts"],
+    "compilerOptions": {
+        "declaration": false,
+        "outDir": "../../scripts/release",
+        "rootDir": "src",
+        "types": ["node"]
+    }
+}

--- a/packages/release-script/tsconfig.json
+++ b/packages/release-script/tsconfig.json
@@ -1,0 +1,12 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "references": [{ "path": "tsconfig.build.json" }, { "path": "tsconfig.spec.json" }],
+    "files": [],
+    "include": [],
+    "compilerOptions": {
+        "lib": ["ES2024"],
+        "module": "NodeNext",
+        "moduleResolution": "NodeNext",
+        "target": "ES2023"
+    }
+}

--- a/packages/release-script/tsconfig.spec.json
+++ b/packages/release-script/tsconfig.spec.json
@@ -1,0 +1,9 @@
+{
+    "extends": "./tsconfig.json",
+    "files": ["vitest.config.ts"],
+    "include": ["src/**/*.ts"],
+    "compilerOptions": {
+        "outDir": "../../out-tsc/spec",
+        "types": ["node", "vitest/globals"]
+    }
+}

--- a/packages/release-script/vitest.config.ts
+++ b/packages/release-script/vitest.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from 'vitest/config';
+
+const isCI = Boolean(process.env['CI']);
+
+export default defineConfig({
+    test: {
+        clearMocks: true,
+        coverage: {
+            enabled: true,
+            provider: 'v8',
+            reporter: ['text-summary', 'html', 'cobertura'],
+            reportOnFailure: true,
+            reportsDirectory: 'coverage/',
+        },
+        environment: 'node',
+        globals: true,
+        name: 'release-script',
+        open: false,
+        passWithNoTests: true,
+        reporters: ['dot', ['html', { outputFile: 'reports/index.html' }], ...(isCI ? ['github-actions'] : [])],
+        root: import.meta.dirname,
+    },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -489,6 +489,36 @@ importers:
         specifier: catalog:eslint
         version: 8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@5.9.3)
 
+  packages/release-script:
+    devDependencies:
+      '@dnd-mapp/eslint-config':
+        specifier: workspace:*
+        version: link:../eslint-config
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.12.4
+      '@vitest/coverage-v8':
+        specifier: catalog:vitest
+        version: 4.1.7(@vitest/browser@4.1.7)(vitest@4.1.7)
+      '@vitest/ui':
+        specifier: catalog:vitest
+        version: 4.1.7(vitest@4.1.7)
+      eslint:
+        specifier: catalog:eslint
+        version: 10.4.1(jiti@2.7.0)
+      eslint-config-prettier:
+        specifier: catalog:eslint
+        version: 10.1.8(eslint@10.4.1(jiti@2.7.0))
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      typescript-eslint:
+        specifier: catalog:eslint
+        version: 8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@5.9.3)
+      vitest:
+        specifier: catalog:vitest
+        version: 4.1.7(@types/node@24.12.4)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+
   packages/sigil:
     devDependencies:
       '@dnd-mapp/stylelint-config':

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "references": [
         { "path": "./apps/realm/tsconfig.json" },
         { "path": "./e2e/realm/tsconfig.json" },
-        { "path": "./packages/arcane-ui/tsconfig.json" }
+        { "path": "./packages/arcane-ui/tsconfig.json" },
+        { "path": "./packages/release-script/tsconfig.json" }
     ]
 }


### PR DESCRIPTION
## Summary

### Context

ADR 0020 defines a PR-based monorepo release workflow driven by an interactive TypeScript script at `packages/release-script`. This PR scaffolds that package — no implementation logic yet, just the correct structure and workspace wiring — so that subsequent implementation work has a solid foundation.

### Changes

Added a `./node` entry point to `@dnd-mapp/eslint-config` providing `typescript-eslint` `strictTypeChecked` rules for Node.js and CLI packages, then used it to scaffold `packages/release-script`:

- `package.json` (`@dnd-mapp/release-script`), private ESM, with `build`, `lint-ts`, `test`, and `test-ci` scripts and catalog devDependencies including `@vitest/ui` for HTML test reporting
- Three tsconfigs: `tsconfig.json` (composite root), `tsconfig.build.json` (compiles `src/` to `scripts/release/`), `tsconfig.spec.json` (test files and `vitest.config.ts`)
- `vitest.config.ts` in Node mode with v8 coverage and HTML reporting
- `moon.yml` with `build`, `lint-ts`, `test`, and `test-ci` tasks; `build` outputs to `/scripts/release/**` in the workspace root
- `src/index.ts` shebang stub as the bin entry point
- `CHANGELOG.md` (empty Unreleased, no reference links per ADR 0019) and `README.md`

Workspace wiring: project registered in `.moon/workspace.yml` and root `tsconfig.json` references; `root:release` Moon task added that auto-builds the package and runs `node scripts/release/index.js`. Added `/scripts/release/` and `/out-tsc/` to `.gitignore`. Updated root README to list all previously missing packages (arcane-ui, sigil, release-script).

## Test Plan

- [ ] `pnpm install` resolves without errors
- [ ] `moon run release-script:build` — tsc compiles and `scripts/release/index.js` appears at the repo root
- [ ] `moon run release-script:lint-ts` — ESLint passes on the stub and `vitest.config.ts`
- [ ] `moon run release-script:test-ci` — Vitest exits 0 with no test files
- [ ] `moon run root:release` — builds the package and runs the stub without error

Closes: #173