### PR TITLE
chore(sigil): Add eslint.config.mjs and lint-ts

### DIFF
--- a/packages/sigil/eslint.config.mjs
+++ b/packages/sigil/eslint.config.mjs
@@ -1,0 +1,3 @@
+import baseConfig from '@dnd-mapp/eslint-config';
+
+export default [{ ignores: ['dist/'] }, ...baseConfig];

--- a/packages/sigil/moon.yml
+++ b/packages/sigil/moon.yml
@@ -26,3 +26,10 @@ tasks:
             - 'src/**/*.scss'
             - '.stylelintrc.json'
             - '/packages/stylelint-config/src/**/*.mjs'
+
+    lint-ts:
+        command: 'pnpm lint-ts'
+        inputs:
+            - 'scripts/**/*.mjs'
+            - 'eslint.config.mjs'
+            - '/packages/eslint-config/src/**/*.mjs'

--- a/packages/sigil/package.json
+++ b/packages/sigil/package.json
@@ -33,10 +33,13 @@
     "postbuild": "node scripts/post-build.mjs",
     "build": "sass --pkg-importer=node src/index.scss:./dist/index.css src/normalize.scss:./dist/normalize.css src/base.scss:./dist/base.css --source-map",
     "build-dev": "sass --watch --pkg-importer=node src/index.scss:./dist/index.css src/normalize.scss:./dist/normalize.css src/base.scss:./dist/base.css --source-map",
-    "lint-css": "stylelint \"src/**/*.scss\""
+    "lint-css": "stylelint \"src/**/*.scss\"",
+    "lint-ts": "eslint scripts/"
   },
   "devDependencies": {
+    "@dnd-mapp/eslint-config": "workspace:*",
     "@dnd-mapp/stylelint-config": "workspace:*",
+    "eslint": "catalog:eslint",
     "@fontsource-variable/inconsolata": "catalog:",
     "@fontsource-variable/lora": "catalog:",
     "@fontsource/metamorphous": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -491,6 +491,9 @@ importers:
 
   packages/sigil:
     devDependencies:
+      '@dnd-mapp/eslint-config':
+        specifier: workspace:*
+        version: link:../eslint-config
       '@dnd-mapp/stylelint-config':
         specifier: workspace:*
         version: link:../stylelint-config
@@ -503,6 +506,9 @@ importers:
       '@fontsource/metamorphous':
         specifier: 'catalog:'
         version: 5.2.8
+      eslint:
+        specifier: catalog:eslint
+        version: 10.4.1(jiti@2.7.0)
       modern-normalize:
         specifier: 'catalog:'
         version: 3.0.1


### PR DESCRIPTION
## Summary

### Context

`packages/sigil` is a pure CSS/SCSS design-token library that had no ESLint coverage for its two Node.js MJS build scripts (`scripts/download-fonts.mjs` and `scripts/post-build.mjs`). Only Stylelint for SCSS was configured.

### Changes

Added `eslint.config.mjs` to `packages/sigil/` extending the base `@dnd-mapp/eslint-config` export (which covers `**/*.{js,mjs,cjs}` files). Added a `lint-ts` npm script (`eslint scripts/`) and the corresponding moon task with input tracking for `scripts/**/*.mjs`, `eslint.config.mjs`, and the shared eslint-config source. Added `@dnd-mapp/eslint-config` and `eslint` as devDependencies.

## Test Plan

- [x] Run `moon run sigil:lint-ts` and confirm it exits 0 with no lint errors.
- [x] Run `moon run :lint-ts` across all packages and confirm no regressions.

Closes: #204