### PR TITLE
ci(pull-request): Use moon ci target selection

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -46,7 +46,7 @@ jobs:
               shell: bash
               env:
                   MOON_REMOTE_HOST: grpc://docker-bazel-remote:9092
-              run: pnpm moon ci
+              run: pnpm moon ci :build :test-ci :lint-ts :lint-css :storybook-build :lint-md :format-check
 
             - name: Report CI results
               uses: moonrepo/run-report-action@bbe7e99bf2aca819ec660ec01fc59d84bdd492d6 # v1.10.0
@@ -145,7 +145,7 @@ jobs:
             - name: Run E2E tests
               env:
                   MOON_REMOTE_HOST: grpc://docker-bazel-remote:9092
-              run: pnpm moon run realm-e2e:e2e-ci
+              run: pnpm moon ci :e2e-ci
 
             - name: Upload E2E reports
               if: failure()


### PR DESCRIPTION
## Summary

### Context

The CI workflow's `ci` job used `pnpm moon ci` with no task filters, which relies on Moon's default behaviour to determine what to run across all affected projects. The `e2e` job used `pnpm moon run realm-e2e:e2e-ci` — a direct task reference rather than the `ci` command — which bypasses Moon's affected-task selection. Making the task scope explicit on both jobs ensures only the intended validation tasks run on each PR and keeps the two jobs consistent in how they invoke Moon.

### Changes

In the `ci` job, `pnpm moon ci` is replaced with `pnpm moon ci :build :test-ci :lint-ts :lint-css :storybook-build :lint-md :format-check` to enumerate the exact task tags that should run for PR validation. In the `e2e` job, `pnpm moon run realm-e2e:e2e-ci` is replaced with `pnpm moon ci :e2e-ci` to align with the `ci`-command approach and enable affected-task filtering for E2E as well.

## Test Plan

- [x] Open a PR and confirm both the `ci` and `e2e` jobs complete successfully.
- [x] Check the Moon run report posted to the PR to confirm only the listed task tags ran in the `ci` job.

Closes: #205