### PR TITLE
chore(moon): Add project-level file groups

### DIFF
--- a/apps/realm/moon.yml
+++ b/apps/realm/moon.yml
@@ -4,6 +4,26 @@ language: 'typescript'
 stack: 'frontend'
 layer: 'application'
 
+fileGroups:
+    sources:
+        - '**/*.{ts,html}'
+        - 'public/**/*'
+        - '!**/test/**'
+        - '!dist/**'
+        - '!.angular/**'
+        - '!coverage/**'
+        - '!reports/**'
+    tests:
+        - '**/test/**/*.ts'
+        - '.msw/**/*'
+    configs:
+        - 'tsconfig*.json'
+        - 'package.json'
+        - 'angular.json'
+        - 'vitest.config.mts'
+        - 'eslint.config.mjs'
+        - '.stylelintrc.json'
+
 tasks:
     start:
         command: 'pnpm start'

--- a/e2e/realm/moon.yml
+++ b/e2e/realm/moon.yml
@@ -4,6 +4,15 @@ language: 'typescript'
 stack: 'frontend'
 layer: 'automation'
 
+fileGroups:
+    sources:
+        - 'src/**/*.ts'
+    tests: []
+    configs:
+        - 'tsconfig*.json'
+        - 'playwright.config.ts'
+        - 'eslint.config.mjs'
+
 dependsOn:
     - realm
 

--- a/moon.yml
+++ b/moon.yml
@@ -4,6 +4,19 @@ language: 'javascript'
 stack: 'unknown'
 layer: 'tool'
 
+fileGroups:
+    sources:
+        - '**/*.{js,cjs,mjs}'
+        - '!apps/**'
+        - '!packages/**'
+        - '!e2e/**'
+    tests: []
+    configs:
+        - '.prettierrc'
+        - '.prettierignore'
+        - '.markdownlint-cli2.json'
+        - 'package.json'
+
 tasks:
     playwright-install:
         command: 'pnpm playwright-install'

--- a/packages/arcane-ui/moon.yml
+++ b/packages/arcane-ui/moon.yml
@@ -4,6 +4,27 @@ language: 'typescript'
 stack: 'frontend'
 layer: 'library'
 
+fileGroups:
+    sources:
+        - '**/*.{ts,html,scss}'
+        - '!**/*.spec.ts'
+        - '!dist/**'
+        - '!.angular/**'
+        - '!coverage/**'
+        - '!reports/**'
+    tests:
+        - '**/*.spec.ts'
+        - '.msw/**/*'
+    configs:
+        - 'tsconfig*.json'
+        - '**/ng-package.json'
+        - 'package.json'
+        - 'angular.json'
+        - 'vitest.config.mts'
+        - 'eslint.config.mjs'
+        - '.stylelintrc.json'
+        - '.storybook/**'
+
 tasks:
     build:
         command: 'pnpm build'

--- a/packages/eslint-config/moon.yml
+++ b/packages/eslint-config/moon.yml
@@ -4,6 +4,13 @@ language: 'javascript'
 stack: 'unknown'
 layer: 'configuration'
 
+fileGroups:
+    sources:
+        - 'src/**/*.mjs'
+    tests: []
+    configs:
+        - 'eslint.config.mjs'
+
 tasks:
     lint-ts:
         command: 'pnpm lint-ts'

--- a/packages/sigil/moon.yml
+++ b/packages/sigil/moon.yml
@@ -4,6 +4,18 @@ language: 'scss'
 stack: 'frontend'
 layer: 'library'
 
+fileGroups:
+    sources:
+        - 'src/**/*.scss'
+        - 'assets/**/*'
+    tests: []
+    configs:
+        - 'package.json'
+        - 'README.md'
+        - 'scripts/post-build.mjs'
+        - 'eslint.config.mjs'
+        - '.stylelintrc.json'
+
 tasks:
     build:
         command: 'pnpm build'

--- a/packages/stylelint-config/moon.yml
+++ b/packages/stylelint-config/moon.yml
@@ -4,6 +4,13 @@ language: 'javascript'
 stack: 'unknown'
 layer: 'configuration'
 
+fileGroups:
+    sources:
+        - 'src/**/*.mjs'
+    tests: []
+    configs:
+        - 'eslint.config.mjs'
+
 tasks:
     lint-ts:
         command: 'pnpm lint-ts'


### PR DESCRIPTION
## Summary

### Context

Each project `moon.yml` needs named `fileGroups` before issue #197 can introduce inherited tasks in `.moon/tasks.yml` that reference them via `@globs()`. This PR adds those groups as a prerequisite.

### Changes

Adds `sources`, `tests`, and `configs` file groups to all seven project `moon.yml` files (`realm`, `arcane-ui`, `sigil`, `eslint-config`, `stylelint-config`, `realm-e2e`, `root`).

Key decisions:

- `sources` for `realm` and `arcane-ui` explicitly exclude output directories (`dist/`, `.angular/`, `coverage/`, `reports/`) and test files so that build and Storybook tasks are not invalidated by test-only changes.
- `tests` for `arcane-ui` covers co-located specs (`**/*.spec.ts`) and MSW mock handlers (`.msw/**/*`); `realm` uses `**/test/**/*.ts` and `.msw/**/*` for the same reason.
- Projects without a dedicated test directory (`sigil`, `eslint-config`, `stylelint-config`, `realm-e2e`, `root`) have an empty `tests` group.
- Existing task `inputs` are not modified — that refactor is deferred to #197.

## Test Plan

- [x] Run `moon check --all` — all tasks should produce identical results to before since task `inputs` are unchanged and no tasks reference the new groups yet.

Refs: #201