### PR TITLE
chore(moon): Use inherited task inputs per project

### DIFF
--- a/apps/realm/moon.yml
+++ b/apps/realm/moon.yml
@@ -6,7 +6,7 @@ layer: 'application'
 
 fileGroups:
     sources:
-        - '**/*.{ts,html}'
+        - '**/*.{ts,html,scss}'
         - 'public/**/*'
         - '!**/test/**'
         - '!dist/**'
@@ -74,5 +74,3 @@ tasks:
 
     lint-css:
         command: 'pnpm lint-css'
-        inputs:
-            - 'src/**/*.scss'

--- a/packages/arcane-ui/moon.yml
+++ b/packages/arcane-ui/moon.yml
@@ -73,6 +73,9 @@ tasks:
             - 'coverage/**'
             - 'reports/**'
 
+    lint-ts:
+        command: 'pnpm lint-ts'
+
     test:
         command: 'pnpm test'
         preset: 'server'

--- a/packages/eslint-config/moon.yml
+++ b/packages/eslint-config/moon.yml
@@ -20,7 +20,3 @@ workspace:
 tasks:
     lint-ts:
         command: 'pnpm lint-ts'
-        inputs:
-            - 'src/**/*.mjs'
-            - 'eslint.config.mjs'
-            - '/eslint.config.mjs'

--- a/packages/stylelint-config/moon.yml
+++ b/packages/stylelint-config/moon.yml
@@ -20,7 +20,3 @@ workspace:
 tasks:
     lint-ts:
         command: 'pnpm lint-ts'
-        inputs:
-            - 'src/**/*.mjs'
-            - 'eslint.config.mjs'
-            - '/eslint.config.mjs'


### PR DESCRIPTION
## Summary

### Context

PR #213 (issue #202) introduced workspace-level inherited task definitions in `.moon/tasks.yml`, giving `lint-ts`, `lint-css`, and `test-ci` globally-defined input sets driven by `@globs()` file-group references. The per-project `moon.yml` files still carried explicit `inputs` lists that duplicated what those file groups now compute automatically, adding noise and drift risk.

Additionally, `arcane-ui` was missing a local `lint-ts` stub, causing the task to be unresolvable because Moon 2.x does not automatically expose inherited tasks without a local registration entry.

### Changes

- **`eslint-config` and `stylelint-config`**: removed explicit `inputs` from `lint-ts`; inputs are now computed by `@globs(sources)`, `@globs(configs)`, `@globs(eslint-config-files)`, and `@globs(typescript-base-configs)`.
- **`arcane-ui`**: added a minimal `lint-ts` stub (`command: 'pnpm lint-ts'`) to register the inherited task for the project.
- **`realm`**: added `scss` to the `sources` file group so `@globs(sources)` covers SCSS files; removed the explicit `inputs: ['src/**/*.scss']` from `lint-css`.

## Test Plan

- [ ] `moon run eslint-config:lint-ts` resolves and exits clean
- [ ] `moon run stylelint-config:lint-ts` resolves and exits clean
- [ ] `moon run arcane-ui:lint-ts` resolves and exits clean
- [ ] `moon run realm:lint-css` resolves and exits clean
- [ ] Second run on each is a cache hit, confirming inputs are correctly wired

Closes: #203