### PR TITLE
Improve Realm Docker Hub README and add local build docs

### DIFF
--- a/.commitlintrc
+++ b/.commitlintrc
@@ -1,7 +1,0 @@
-{
-    "extends": ["@commitlint/config-conventional"],
-    "rules": {
-        "subject-case": [2, "never", ["start-case", "pascal-case", "upper-case"]],
-        "header-max-length": [2, "always", 72]
-    }
-}

--- a/.docker/realm/README.md
+++ b/.docker/realm/README.md
@@ -1,14 +1,20 @@
 # dndmapp/realm
 
-Angular SPA for D&D Mapp, served by nginx on port 4000.
+[![Docker Pulls](https://img.shields.io/docker/pulls/dndmapp/realm)](https://hub.docker.com/r/dndmapp/realm)
+[![CI](https://img.shields.io/github/actions/workflow/status/dnd-mapp/dma-platform/push-main.yml?label=CI)](https://github.com/dnd-mapp/dma-platform/actions/workflows/push-main.yml)
+[![License: MIT](https://img.shields.io/github/license/dnd-mapp/dma-platform)](https://github.com/dnd-mapp/dma-platform/blob/main/LICENSE)
+
+Angular SPA for D&D Mapp, served by nginx on port 4000. Part of the D&D Mapp stack — authentication and API calls require Gatekeeper and other companion services to function.
+
+**Source:** [dnd-mapp/dma-platform](https://github.com/dnd-mapp/dma-platform)
 
 ## Tags
 
-| Tag          | Description                                                   |
-|--------------|---------------------------------------------------------------|
-| `next`       | Latest build from `main` — use this for deployments           |
-| `pr-{N}`     | Ephemeral build for PR #N — CI-only, do not use in production |
-| `buildcache` | Internal BuildKit cache layer — do not pull                   |
+| Tag          | Description                                                                |
+|:-------------|:---------------------------------------------------------------------------|
+| `next`       | Latest build from `main` — use this for deployments                        |
+| `pr-{N}`     | Ephemeral build for PR #N — CI-only, do not use in production              |
+| `buildcache` | Internal BuildKit cache layer, not a runnable image — do not pull directly |
 
 ## Configuration
 
@@ -21,7 +27,7 @@ Runtime configuration is supplied by mounting a `config.json` file into the cont
 ### Schema
 
 | Key | Type | Required | Description                                                                            |
-|-----|------|----------|----------------------------------------------------------------------------------------|
+|:----|:-----|:---------|:---------------------------------------------------------------------------------------|
 | —   | —    | —        | No configuration keys yet — this table will grow as backend services are containerised |
 
 Minimal example:
@@ -61,14 +67,4 @@ services:
 
 ## Building from source
 
-Prerequisites: Docker with BuildKit enabled, repository cloned.
-
-```sh
-docker buildx bake -f .docker/bake.hcl realm
-```
-
-The bake target builds for `linux/amd64` and `linux/arm64` by default. To restrict to a single platform for local development:
-
-```sh
-docker buildx bake -f .docker/bake.hcl realm --set realm.platforms=linux/amd64
-```
+See [Building the Docker image](https://github.com/dnd-mapp/dma-platform/blob/main/apps/realm/README.md#building-the-docker-image) in the source repository.

--- a/apps/realm/README.md
+++ b/apps/realm/README.md
@@ -28,3 +28,26 @@ The app will be available at `https://realm.dnd-mapp.localhost`.
 Tests are run in a real Chromium browser via Playwright. Coverage reports are written to `coverage/apps/realm/` and HTML test reports to `reports/apps/realm/`.
 
 End-to-end tests live in [`e2e/realm`](../../e2e/realm) and are run separately via `pnpm --filter @dnd-mapp/realm-e2e test`.
+
+## Building the Docker image
+
+The image is built with [Docker Bake](https://docs.docker.com/build/bake/) using [`.docker/bake.hcl`](../../.docker/bake.hcl).
+
+In CI, `docker/metadata-action` generates a supplementary bake file that populates the `docker-metadata-action` target with image tags and dynamic OCI labels (`org.opencontainers.image.created`, `.revision`, `.version`). That file is not available locally, so you must supply those values via `--set` flags:
+
+```sh
+docker buildx bake \
+  --file .docker/bake.hcl \
+  --set realm.tags=realm:local \
+  --set "realm.labels.org.opencontainers.image.created=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --set "realm.labels.org.opencontainers.image.revision=$(git rev-parse HEAD)" \
+  --set "realm.labels.org.opencontainers.image.version=local" \
+  --set realm.platform=linux/amd64 \
+  --load \
+  realm
+```
+
+`--set realm.platform=linux/amd64` restricts the build to a single architecture so `--load` can import the result into the local Docker store. Use `linux/arm64` instead on Apple Silicon.
+
+> [!NOTE]
+> The bake file references a registry-based build cache (`dndmapp/realm:buildcache`). Cache-pull errors during local builds are non-fatal and can be ignored if you are not authenticated to Docker Hub.

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -1,0 +1,19 @@
+/** @type {import('@commitlint/types').UserConfig} */
+module.exports = {
+    extends: ['@commitlint/config-conventional'],
+    plugins: [
+        {
+            rules: {
+                'subject-first-char-case': ({ subject }) => [
+                    !subject || /^[A-Z]/.test(subject),
+                    'subject must start with an uppercase letter',
+                ],
+            },
+        },
+    ],
+    rules: {
+        'subject-case': [2, 'never', ['pascal-case', 'upper-case']],
+        'subject-first-char-case': [2, 'always'],
+        'header-max-length': [2, 'always', 72],
+    },
+};

--- a/scripts/release/index.js
+++ b/scripts/release/index.js
@@ -1,2 +1,0 @@
-#!/usr/bin/env node
-export {};


### PR DESCRIPTION
## Summary

### Context

The Docker Hub README for `dndmapp/realm` was missing useful metadata (badges, source link), had an ambiguous `buildcache` tag description, and included build instructions that belong in the developer README rather than on Docker Hub. Separately, the commitlint configuration was not enforcing the project's commit style (uppercase first letter on subjects) that the `validate.sh` script already checks for.

### Changes

The Docker Hub README (`.docker/realm/README.md`) gains Docker Pulls, CI status, and license badges; a companion services note in the intro; a GitHub source link; a clarified `buildcache` tag description; and a cross-reference to the source repository in place of the full build instructions. The developer README (`apps/realm/README.md`) gains a "Building the Docker image" section with the full Docker Bake workflow, including the `--set` flags needed locally to substitute for CI's `docker/metadata-action` output. The commitlint config is converted from a JSON `.commitlintrc` to `commitlint.config.cjs` with a custom `subject-first-char-case` rule that enforces an uppercase first letter on commit subjects, matching the existing `validate.sh` behaviour. An empty `scripts/release/index.js` stub is also removed.

## Test Plan

- [ ] Verify the Docker Hub README renders correctly — badges resolve, links point to the right pages
- [x] Verify the local Docker build command in `apps/realm/README.md` works as documented
- [x] Verify commitlint rejects a commit with a lowercase-first subject
- [x] Verify commitlint accepts a commit with an uppercase-first subject