### PR TITLE
test(release-script): Add missing test coverage

### DIFF
--- a/packages/release-script/src/changelog.spec.ts
+++ b/packages/release-script/src/changelog.spec.ts
@@ -212,6 +212,12 @@ describe('serializeChangelog', () => {
         expect(result.endsWith('\n')).toBe(true);
     });
 
+    it('omits the reference-link block for a fresh changelog with no versioned entries', () => {
+        const result = serializeChangelog(parseChangelog(FIXTURE_INITIAL));
+
+        expect(result).not.toMatch(/^\[Unreleased\]:/m);
+    });
+
     it('places [Unreleased] link before versioned links', () => {
         const changelog = parseChangelog(FIXTURE_INITIAL);
         const result = serializeChangelog(

--- a/packages/release-script/src/git.spec.ts
+++ b/packages/release-script/src/git.spec.ts
@@ -92,6 +92,13 @@ describe('getCommitsSinceTag', () => {
 
         expect(getCommitsSinceTag('sigil@0.1.0', 'packages/sigil')).toEqual([]);
     });
+
+    it('passes the package path to the git log command', () => {
+        mockExecSync.mockReturnValue('');
+        getCommitsSinceTag('sigil@0.1.0', 'packages/sigil');
+
+        expect(mockExecSync).toHaveBeenCalledWith(expect.stringContaining('-- "packages/sigil"'), expect.anything());
+    });
 });
 
 describe('deriveBumpType', () => {
@@ -131,6 +138,15 @@ describe('deriveBumpType', () => {
                 { subject: 'fix!: Remove thing', body: '' },
             ]),
         ).toBe('major');
+    });
+
+    it('minor wins over patch when feat and fix commits are present', () => {
+        expect(
+            deriveBumpType([
+                { subject: 'fix: Correct token', body: '' },
+                { subject: 'feat: Add colour alias', body: '' },
+            ]),
+        ).toBe('minor');
     });
 });
 


### PR DESCRIPTION
## Summary

### Context

Issue #178 required Vitest unit tests (Node mode) for the `release-script` package's changelog and git utilities. Both `changelog.spec.ts` and `git.spec.ts` already existed with substantial coverage written alongside the implementation, but three behaviours called out in the issue had no dedicated test case.

### Changes

Added three focused test cases to close the coverage gaps:

- `getCommitsSinceTag` — verifies that `packagePath` appears after the `--` path separator in the `git log` command, exercising the per-package commit filtering.
- `deriveBumpType` — verifies that `minor` beats `patch` when a `feat` and a `fix` commit coexist (complements the existing "major wins over minor" test).
- `serializeChangelog` — explicitly asserts that no `[Unreleased]:` reference-link line is emitted for a fresh changelog that has no versioned entries yet.

## Test Plan

- [x] Run `cd packages/release-script && pnpm test-ci` — all 55 tests pass, coverage stays at 100% across statements, branches, functions, and lines.

Fixes: #178