### PR TITLE
ci: Add release job skeleton to pr-closed workflow

### DIFF
--- a/.github/workflows/pr-closed.yml
+++ b/.github/workflows/pr-closed.yml
@@ -23,3 +23,29 @@ jobs:
                   token: ${{ secrets.DOCKERHUB_TOKEN }}
                   repository: dndmapp/realm
                   tag: pr-${{ github.event.number }}
+
+    release:
+        name: Release
+        if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/')
+        runs-on: ubuntu-22.04
+        timeout-minutes: 10
+        permissions:
+            contents: write
+        steps:
+            - name: Checkout
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+              with:
+                  fetch-depth: 0
+
+            - name: Extract package name and version
+              id: extract
+              run: |
+                  branch="${{ github.head_ref }}"
+                  branch="${branch#release/}"
+                  if [[ "$branch" =~ ^(.+)-([0-9]+\.[0-9]+\.[0-9].*)$ ]]; then
+                      echo "name=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
+                      echo "version=${BASH_REMATCH[2]}" >> "$GITHUB_OUTPUT"
+                  else
+                      echo "::error::Branch name does not match pattern 'release/<name>-<version>'"
+                      exit 1
+                  fi


### PR DESCRIPTION
## Summary

### Context

ADR 0020 defines a two-stage monorepo release workflow. Stage 1 (the interactive release script, issues #173–179) creates a `release/<name>-<version>` branch and opens a PR to `main`. Stage 2 — this job — needs to fire automatically once that PR is merged to create a git tag, publish a GitHub Release, and (for `realm`) promote Docker image tags.

### Changes

Adds a `release` job to the existing `pr-closed.yml` workflow rather than a new file, since the trigger (`pull_request: types: [closed]`) is already there. The job runs only when `merged == true` and the source branch matches `release/**`, mirroring the conditional pattern used by the existing `docker-cleanup` job. It checks out the full history and exposes `name` and `version` step outputs extracted from the branch name via a bash regex that correctly handles hyphenated package names (`eslint-config`, `release-script`) and pre-release version suffixes (`1.0.0-alpha.1`).

## Test Plan

- [x] Merge a PR from a `release/**` branch and confirm the `release` job runs in Actions
- [x] Merge or close a PR from a non-`release/**` branch and confirm only `docker-cleanup` runs (or neither, if merged)
- [x] Verify step output `name` and `version` are populated correctly for a branch like `release/eslint-config-1.2.0`

Closes: #180