### PR TITLE
ci(release): Add signed git tag creation to release-merge workflow

### DIFF
--- a/.github/workflows/pr-closed.yml
+++ b/.github/workflows/pr-closed.yml
@@ -42,6 +42,7 @@ jobs:
               run: |
                   branch="${{ github.head_ref }}"
                   branch="${branch#release/}"
+
                   if [[ "$branch" =~ ^(.+)-([0-9]+\.[0-9]+\.[0-9].*)$ ]]; then
                       echo "name=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
                       echo "version=${BASH_REMATCH[2]}" >> "$GITHUB_OUTPUT"
@@ -49,3 +50,25 @@ jobs:
                       echo "::error::Branch name does not match pattern 'release/<name>-<version>'"
                       exit 1
                   fi
+
+            - name: Create and push git tag
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  TAG: ${{ steps.extract.outputs.name }}@${{ steps.extract.outputs.version }}
+                  NAME: ${{ steps.extract.outputs.name }}
+                  VERSION: ${{ steps.extract.outputs.version }}
+              run: |
+                  sha=$(git rev-parse HEAD)
+
+                  tag_sha=$(gh api repos/dnd-mapp/dma-platform/git/tags \
+                    --method POST \
+                    --field tag="$TAG" \
+                    --field message="Release $NAME $VERSION" \
+                    --field object="$sha" \
+                    --field type="commit" \
+                    --jq '.sha')
+
+                  gh api repos/dnd-mapp/dma-platform/git/refs \
+                    --method POST \
+                    --field ref="refs/tags/$TAG" \
+                    --field sha="$tag_sha"

--- a/docs/adr/0024-github-api-bot-signing-for-release-tags.md
+++ b/docs/adr/0024-github-api-bot-signing-for-release-tags.md
@@ -1,0 +1,31 @@
+# ADR 0024: GitHub API bot signing for release tags
+
+- **Status:** Accepted
+- **Date:** 2026-06-08
+
+## Context
+
+Release tags created by the `release-merge` workflow (ADR 0020) need to be signed to prevent supply-chain impersonation and provide tamper-evidence.
+
+Three approaches were considered:
+
+- **Long-lived GPG/SSH key stored as a GitHub Actions secret** — classical, verifiable with plain `git verify-tag`, but requires key generation, storage, rotation, and revocation management.
+
+- **Sigstore/Gitsign (keyless)** — ephemeral certificate via GitHub's OIDC token; signatures logged in the Rekor transparency log; independent audit trail. Requires installing the `gitsign` binary and using `gitsign verify-tag` for verification.
+
+- **GitHub API bot signing** — create the tag object via the GitHub Git Tags API authenticated as `github-actions[bot]`; GitHub marks the tag as **Verified** server-side per its bot signature verification policy. No external tooling, no key management, no additional permissions.
+
+## Decision
+
+Use the GitHub API to create release tags authenticated as `github-actions[bot]` (`GITHUB_TOKEN`). Two API calls replace `git tag` + `git push`: one to create the annotated tag object, one to create the ref. GitHub signs the object and marks it as **Verified** in the UI.
+
+Sigstore/Gitsign was ruled out because an independent external audit trail is not required; GitHub's own verification record satisfies the supply-chain and integrity goals.
+
+Tags carry a human-readable message: `Release <name> <version>` (e.g. `Release sigil 1.2.0`).
+
+## Consequences
+
+- No key management or external tooling required.
+- The **Verified** badge is visible on the tag in the GitHub UI and via the GitHub API (`/repos/{owner}/{repo}/git/tags/{sha}`).
+- Verification is GitHub-internal; there is no independently verifiable cryptographic proof outside of GitHub's infrastructure.
+- The workflow requires no permissions beyond the existing `contents: write`.


### PR DESCRIPTION
## Summary

### Context

The release-merge workflow was scaffolded in PR #224 with a skeleton that extracts the package name and version from the release branch name. This change implements the next step: creating and pushing the annotated git tag `<name>@<version>` after a release PR merges.

### Changes

Added a `Create and push git tag` step to the `release` job in `.github/workflows/pr-closed.yml`. Rather than using `git tag` + `git push`, the step calls the GitHub Git Tags API and Git Refs API via `gh api`, authenticated as `github-actions[bot]`. GitHub marks tags created this way as **Verified** in the UI, providing tamper-evidence and supply-chain impersonation prevention without requiring key management or additional permissions beyond the existing `contents: write`.

Tags are annotated with the human-readable message `Release <name> <version>` (e.g. `Release sigil 1.2.0`).

Also adds ADR 0024, documenting why the GitHub API bot-signing approach was chosen over GPG/SSH keys or Sigstore/Gitsign.

## Test Plan

- [x] Merge a release PR (e.g. `release/sigil-x.y.z`) and confirm the tag `sigil@x.y.z` appears in `git tag -l`
- [x] Verify the tag shows a **Verified** badge in the GitHub UI
- [x] Confirm the tag is annotated: `git cat-file tag <name>@<version>` shows the `Release <name> <version>` message

Closes: #181