### PR TITLE
ci(release): Create GitHub Release from CHANGELOG

### DIFF
--- a/.github/workflows/pr-closed.yml
+++ b/.github/workflows/pr-closed.yml
@@ -39,6 +39,7 @@ jobs:
 
             - name: Extract package name and version
               id: extract
+              shell: bash
               run: |
                   branch="${{ github.head_ref }}"
                   branch="${branch#release/}"
@@ -57,6 +58,7 @@ jobs:
                   TAG: ${{ steps.extract.outputs.name }}@${{ steps.extract.outputs.version }}
                   NAME: ${{ steps.extract.outputs.name }}
                   VERSION: ${{ steps.extract.outputs.version }}
+              shell: bash
               run: |
                   sha=$(git rev-parse HEAD)
 
@@ -72,3 +74,46 @@ jobs:
                     --method POST \
                     --field ref="refs/tags/$TAG" \
                     --field sha="$tag_sha"
+
+            - name: Extract CHANGELOG section
+              env:
+                  NAME: ${{ steps.extract.outputs.name }}
+                  VERSION: ${{ steps.extract.outputs.version }}
+              shell: bash
+              run: |
+                  if [[ -f "packages/${NAME}/CHANGELOG.md" ]]; then
+                      changelog="packages/${NAME}/CHANGELOG.md"
+                  elif [[ -f "apps/${NAME}/CHANGELOG.md" ]]; then
+                      changelog="apps/${NAME}/CHANGELOG.md"
+                  else
+                      echo "::error::CHANGELOG.md not found for package '${NAME}'"
+                      exit 1
+                  fi
+
+                  awk -v ver="$VERSION" '
+                      /^## \[/{
+                          if (found) exit
+                          if (index($0, "[" ver "]") > 0) found = 1
+                          next
+                      }
+                      found { print }
+                  ' "$changelog" > /tmp/release-notes.md
+
+            - name: Create GitHub Release
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  TAG: ${{ steps.extract.outputs.name }}@${{ steps.extract.outputs.version }}
+                  NAME: ${{ steps.extract.outputs.name }}
+                  VERSION: ${{ steps.extract.outputs.version }}
+              shell: bash
+              run: |
+                  prerelease_flag=()
+
+                  if [[ "$VERSION" == *"-"* ]]; then
+                      prerelease_flag=(--prerelease)
+                  fi
+
+                  gh release create "$TAG" \
+                      --title "$NAME $VERSION" \
+                      --notes-file /tmp/release-notes.md \
+                      "${prerelease_flag[@]}"


### PR DESCRIPTION
## Summary

### Context

The release job in `pr-closed.yml` already parses the branch name (`release/<name>-<version>`) to extract the package name and version, then creates a signed git tag via the GitHub API. Issue #182 adds the final steps: extracting the relevant versioned section from the package's `CHANGELOG.md` and publishing a GitHub Release with it as the body.

### Changes

Two new steps are added to the `release` job in `.github/workflows/pr-closed.yml`. The "Extract CHANGELOG section" step locates the package's `CHANGELOG.md` by checking `packages/<name>/` then `apps/<name>/`, then uses `awk` with `index()` (literal string matching, safe for semver characters) to extract the block between the version heading and the next `## [` heading, writing the result to `/tmp/release-notes.md`. The "Create GitHub Release" step runs `gh release create` against the already-created tag, passing the notes file with `--notes-file`. It adds `--prerelease` automatically when the version string contains a hyphen. Explicit `shell: bash` is also added to all `run:` steps in the release job for consistency.

## Test Plan

- [x] Merge a `release/<name>-<version>` branch and confirm the workflow run completes all four steps successfully
- [x] Verify a GitHub Release appears at the expected tag with the correct title (`<name> <version>`) and a body matching the CHANGELOG section for that version
- [x] Confirm a pre-release version (e.g. `1.0.0-rc.1`) receives the pre-release badge

Closes: #182