### PR TITLE
ci(release): Add Docker image promotion for realm

### DIFF
--- a/.github/workflows/pr-closed.yml
+++ b/.github/workflows/pr-closed.yml
@@ -31,6 +31,9 @@ jobs:
         timeout-minutes: 10
         permissions:
             contents: write
+        outputs:
+            name: ${{ steps.extract.outputs.name }}
+            version: ${{ steps.extract.outputs.version }}
         steps:
             - name: Checkout
               uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -117,3 +120,53 @@ jobs:
                       --title "$NAME $VERSION" \
                       --notes-file /tmp/release-notes.md \
                       "${prerelease_flag[@]}"
+
+    docker-release-promote:
+        name: Docker release promote
+        needs: release
+        if: needs.release.outputs.name == 'realm'
+        runs-on: ubuntu-22.04
+        timeout-minutes: 5
+        permissions: {}
+        steps:
+            - name: Checkout
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+            - name: Compute semver tags
+              id: tags
+              shell: bash
+              run: |
+                  version="${{ needs.release.outputs.version }}"
+                  base="${version%%-*}"
+                  echo "major=${base%%.*}" >> "$GITHUB_OUTPUT"
+                  echo "major_minor=${base%.*}" >> "$GITHUB_OUTPUT"
+
+            - name: Log in to Docker Hub
+              uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+              with:
+                  username: ${{ secrets.DOCKERHUB_USERNAME }}
+                  password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+            - name: Promote to :latest
+              uses: ./.github/actions/docker-promote-image
+              with:
+                  source: dndmapp/realm:next
+                  target: dndmapp/realm:latest
+
+            - name: Promote to :<major>
+              uses: ./.github/actions/docker-promote-image
+              with:
+                  source: dndmapp/realm:next
+                  target: dndmapp/realm:${{ steps.tags.outputs.major }}
+
+            - name: Promote to :<major>.<minor>
+              uses: ./.github/actions/docker-promote-image
+              with:
+                  source: dndmapp/realm:next
+                  target: dndmapp/realm:${{ steps.tags.outputs.major_minor }}
+
+            - name: Promote to :<version>
+              uses: ./.github/actions/docker-promote-image
+              with:
+                  source: dndmapp/realm:next
+                  target: dndmapp/realm:${{ needs.release.outputs.version }}


### PR DESCRIPTION
## Summary

### Context

Issue #183 asks for Docker image promotion on realm release. When a realm release PR merges, the existing `push-main.yml` workflow already promotes the PR image to `dndmapp/realm:next`, but nothing subsequently promotes `:next` to the stable semver tags (`latest`, `<major>`, `<major>.<minor>`, `<version>`). This leaves stable tags stale until this step is added.

### Changes

Adds `outputs` (`name`, `version`) to the existing `release` job in `pr-closed.yml` so downstream jobs can read them. Adds a new `docker-release-promote` job that runs only when `needs.release.outputs.name == 'realm'`, computes `major` and `major_minor` from the version string using bash parameter expansion (correctly stripping pre-release suffixes), logs into Docker Hub, and calls the existing `docker-promote-image` action four times to tag `:latest`, `:<major>`, `:<major>.<minor>`, and `:<version>` from `:next`. Running within the same `pr-closed` workflow prevents a race where a concurrent push-to-main could advance `:next` before promotion completes.

## Test Plan

- [x] Merge a `release/realm-*` PR and verify `docker-release-promote` appears in the Actions run and completes successfully.
- [x] On Docker Hub, confirm `dndmapp/realm:latest`, `dndmapp/realm:<major>`, `dndmapp/realm:<major>.<minor>`, and `dndmapp/realm:<version>` all resolve to the same digest as `dndmapp/realm:next`.
- [x] Merge a non-realm release PR (e.g. `release/arcane-ui-*`) and verify `docker-release-promote` is skipped.
- [x] Merge a regular (non-release) PR and verify neither `release` nor `docker-release-promote` runs.

Closes: #183