### PR TITLE
ci: Use Tailscale FQDN for Bazel remote cache

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -40,12 +40,12 @@ jobs:
                   oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
                   oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
                   tags: tag:github-actions
-                  ping: docker-bazel-remote
+                  ping: bazel-remote.wolf-triggerfish.ts.net
 
             - name: Run CI
               shell: bash
               env:
-                  MOON_REMOTE_HOST: grpc://docker-bazel-remote:9092
+                  MOON_REMOTE_HOST: grpc://bazel-remote.wolf-triggerfish.ts.net:9092
               run: pnpm moon ci :build :test-ci :lint-ts :lint-css :storybook-build :lint-md :format-check
 
             - name: Report CI results
@@ -143,7 +143,7 @@ jobs:
                   oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
                   oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
                   tags: tag:github-actions
-                  ping: docker-bazel-remote
+                  ping: bazel-remote.wolf-triggerfish.ts.net
 
             - name: Start Realm container
               env:
@@ -152,7 +152,7 @@ jobs:
 
             - name: Run E2E tests
               env:
-                  MOON_REMOTE_HOST: grpc://docker-bazel-remote:9092
+                  MOON_REMOTE_HOST: grpc://bazel-remote.wolf-triggerfish.ts.net:9092
               run: pnpm moon ci :e2e-ci
 
             - name: Upload E2E reports

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -50,12 +50,12 @@ jobs:
                   oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
                   oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
                   tags: tag:github-actions
-                  ping: docker-bazel-remote
+                  ping: bazel-remote.wolf-triggerfish.ts.net
 
             - name: Run CI
               shell: bash
               env:
-                  MOON_REMOTE_HOST: grpc://docker-bazel-remote:9092
+                  MOON_REMOTE_HOST: grpc://bazel-remote.wolf-triggerfish.ts.net:9092
               run: pnpm moon ci :format-check :build :storybook-build :test-ci :lint-ts :lint-css :lint-md
 
             - name: Upload code coverage (realm)


### PR DESCRIPTION
## Summary

### Context

CI workflows use Tailscale to connect to the Bazel remote cache for build artifact caching. Previously the host was referenced by the Docker container hostname `docker-bazel-remote`, which is no longer resolvable. The full Tailscale FQDN is required to reach the host.

### Changes

Both the Tailscale `ping` check and the `MOON_REMOTE_HOST` environment variable in `pull-request.yml` and `push-main.yml` are updated to use `bazel-remote.wolf-triggerfish.ts.net` instead of `docker-bazel-remote`.

## Test Plan

- [x] Verify that PR CI workflows connect to the Bazel remote cache successfully after the hostname change
- [x] Verify that `push-main` workflows also connect and cache hits are registered