### PR TITLE
feat(sigil): Add animations.css entry point

### DIFF
--- a/packages/sigil/README.md
+++ b/packages/sigil/README.md
@@ -87,6 +87,45 @@ Each variable compiles to a `var()` with the light-theme primitive as fallback:
 | `tokens/color`      | `$color-surface-*`, `$color-text-*`, `$color-border-*`, `$color-interactive-*` |
 | `tokens/typography` | `$typography-size-*`, `$typography-weight-*`, `$typography-line-height-*`      |
 
+## Consuming animation tokens
+
+Animation keyframes and timing tokens are compiled to `animations.css`. Load it alongside `index.css` wherever spinning animations are used:
+
+In Angular, add it to the `styles` array in `angular.json`:
+
+```json
+{
+    "styles": [
+        "dist/packages/sigil/index.css",
+        "dist/packages/sigil/animations.css"
+    ]
+}
+```
+
+Or link it directly in your HTML shell:
+
+```html
+<link rel="stylesheet" href="dist/packages/sigil/animations.css">
+```
+
+Use the `dma-spin` keyframe and the timing tokens in component styles:
+
+```scss
+.spinner {
+    animation: dma-spin var(--dma-animation-spin-duration) linear infinite;
+    animation-play-state: var(--dma-animation-play-state);
+}
+```
+
+`--dma-animation-play-state` is automatically set to `paused` when `prefers-reduced-motion: reduce` is active, so no extra media query is needed in the component.
+
+### Available animation tokens
+
+| Token                           | Default   | Description                                            |
+|:--------------------------------|:----------|:-------------------------------------------------------|
+| `--dma-animation-play-state`    | `running` | Set to `paused` under `prefers-reduced-motion: reduce` |
+| `--dma-animation-spin-duration` | `0.8s`    | Duration of one full `dma-spin` rotation               |
+
 ## Consuming spacing and radius primitives
 
 Spacing and radius are SCSS-only — they are not compiled to CSS custom properties. Consume them via `@use` at build time using the same load path setup:

--- a/packages/sigil/package.json
+++ b/packages/sigil/package.json
@@ -13,6 +13,7 @@
     ".": "./index.css",
     "./normalize": "./normalize.css",
     "./base": "./base.css",
+    "./animations": "./animations.css",
     "./primitives/*": {
       "sass": "./primitives/_*.scss"
     },
@@ -31,8 +32,8 @@
   "scripts": {
     "download-fonts": "node scripts/download-fonts.mjs",
     "postbuild": "node scripts/post-build.mjs",
-    "build": "sass --pkg-importer=node src/index.scss:./dist/index.css src/normalize.scss:./dist/normalize.css src/base.scss:./dist/base.css --source-map",
-    "build-dev": "sass --watch --pkg-importer=node src/index.scss:./dist/index.css src/normalize.scss:./dist/normalize.css src/base.scss:./dist/base.css --source-map",
+    "build": "sass --pkg-importer=node src/index.scss:./dist/index.css src/normalize.scss:./dist/normalize.css src/base.scss:./dist/base.css src/animations.scss:./dist/animations.css --source-map",
+    "build-dev": "sass --watch --pkg-importer=node src/index.scss:./dist/index.css src/normalize.scss:./dist/normalize.css src/base.scss:./dist/base.css src/animations.scss:./dist/animations.css --source-map",
     "lint-css": "stylelint \"src/**/*.scss\"",
     "lint-ts": "eslint scripts/"
   },

--- a/packages/sigil/src/animations.scss
+++ b/packages/sigil/src/animations.scss
@@ -1,0 +1,20 @@
+@keyframes dma-spin {
+    from {
+        transform: rotate(0deg);
+    }
+
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+:root {
+    --dma-animation-play-state: running;
+    --dma-animation-spin-duration: 0.8s;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    :root {
+        --dma-animation-play-state: paused;
+    }
+}


### PR DESCRIPTION
## Summary

### Context

The Sigil package had no shared entry point for CSS animation keyframes or timing tokens, meaning any component that needed a spin animation would have to duplicate the `@keyframes` definition and `prefers-reduced-motion` handling. Issue #247 calls for a dedicated `./animations` entry point to centralise these primitives.

### Changes

Added `src/animations.scss` defining `@keyframes dma-spin` (360° rotation), a `--dma-animation-play-state` token that defaults to `running` and is set to `paused` when `prefers-reduced-motion: reduce` is active, and a `--dma-animation-spin-duration` token (0.8s). Updated `package.json` to expose the new `./animations` package export and to include the new source→output pair in both the `build` and `build-dev` Sass scripts.

## Test Plan

- [x] Run `pnpm build` inside `packages/sigil` and confirm `dist/animations.css` is generated
- [x] Verify `dist/animations.css` contains `@keyframes dma-spin`, `--dma-animation-play-state`, and `--dma-animation-spin-duration`
- [x] Verify `dist/package.json` exports includes `"./animations": "./animations.css"`
- [x] Verify `dist/animations.css.map` source map is generated alongside the CSS

Closes: #247