### PR TITLE
feat(sigil): Add warning, success, and info tokens

### DIFF
--- a/packages/sigil/src/semantics/_color.scss
+++ b/packages/sigil/src/semantics/_color.scss
@@ -24,6 +24,15 @@
     --color-interactive-primary-hover: #{$color-maroon-300};
     --color-interactive-primary-active: #{$color-maroon-500};
     --color-interactive-danger: #{$color-red-400};
+    --color-interactive-warning: #{$color-yellow-400};
+    --color-interactive-warning-hover: #{$color-yellow-300};
+    --color-interactive-warning-active: #{$color-yellow-500};
+    --color-interactive-success: #{$color-emerald-400};
+    --color-interactive-success-hover: #{$color-emerald-300};
+    --color-interactive-success-active: #{$color-emerald-500};
+    --color-interactive-info: #{$color-sky-400};
+    --color-interactive-info-hover: #{$color-sky-300};
+    --color-interactive-info-active: #{$color-sky-500};
     --color-interactive-focus-on-primary: #{$color-gold-400};
     --color-interactive-focus-on-secondary: #{$color-maroon-300};
 }
@@ -52,6 +61,15 @@
     --color-interactive-primary-hover: #{$color-maroon-700};
     --color-interactive-primary-active: #{$color-maroon-800};
     --color-interactive-danger: #{$color-red-600};
+    --color-interactive-warning: #{$color-yellow-600};
+    --color-interactive-warning-hover: #{$color-yellow-700};
+    --color-interactive-warning-active: #{$color-yellow-800};
+    --color-interactive-success: #{$color-emerald-600};
+    --color-interactive-success-hover: #{$color-emerald-700};
+    --color-interactive-success-active: #{$color-emerald-800};
+    --color-interactive-info: #{$color-sky-600};
+    --color-interactive-info-hover: #{$color-sky-700};
+    --color-interactive-info-active: #{$color-sky-800};
     --color-interactive-focus-on-primary: #{$color-gold-500};
     --color-interactive-focus-on-secondary: #{$color-maroon-400};
 }

--- a/packages/sigil/src/tokens/_color.scss
+++ b/packages/sigil/src/tokens/_color.scss
@@ -23,5 +23,14 @@ $color-interactive-primary: var(--color-interactive-primary, #{$color-maroon-400
 $color-interactive-primary-hover: var(--color-interactive-primary-hover, #{$color-maroon-300});
 $color-interactive-primary-active: var(--color-interactive-primary-active, #{$color-maroon-500});
 $color-interactive-danger: var(--color-interactive-danger, #{$color-red-400});
+$color-interactive-warning: var(--color-interactive-warning, #{$color-yellow-400});
+$color-interactive-warning-hover: var(--color-interactive-warning-hover, #{$color-yellow-300});
+$color-interactive-warning-active: var(--color-interactive-warning-active, #{$color-yellow-500});
+$color-interactive-success: var(--color-interactive-success, #{$color-emerald-400});
+$color-interactive-success-hover: var(--color-interactive-success-hover, #{$color-emerald-300});
+$color-interactive-success-active: var(--color-interactive-success-active, #{$color-emerald-500});
+$color-interactive-info: var(--color-interactive-info, #{$color-sky-400});
+$color-interactive-info-hover: var(--color-interactive-info-hover, #{$color-sky-300});
+$color-interactive-info-active: var(--color-interactive-info-active, #{$color-sky-500});
 $color-interactive-focus-on-primary: var(--color-interactive-focus-on-primary, #{$color-gold-400});
 $color-interactive-focus-on-secondary: var(--color-interactive-focus-on-secondary, #{$color-maroon-300});


### PR DESCRIPTION
## Summary

### Context

Sigil's semantic color layer only defined interactive tokens for `primary` and `danger` states, leaving `warning`, `success`, and `info` states without token coverage. Without these, components that need to express those states would have to reach directly for primitive colors, breaking the design-token abstraction.

### Changes

Adds 9 new CSS custom properties to `src/semantics/_color.scss` — warning, success, and info tokens each with base, `-hover`, and `-active` variants — for both the dark and light theme mixins. Follows the same OKLCH palette pattern as `--color-interactive-primary`: dark theme uses the `400`/`300`/`500` shades, light theme uses `600`/`700`/`800`. Maps to the existing emerald (success), yellow (warning), and sky (info) primitive palettes already in the package.

Also adds the corresponding 9 SCSS token variables in `src/tokens/_color.scss` with dark-theme primitive fallbacks, so consumers can reach for either CSS custom properties or SCSS variables.

## Test Plan

- [x] Run `pnpm moon run sigil:build` and confirm a clean build with no SCSS errors
- [x] Inspect `dist/index.css` and confirm all 9 new tokens appear in both the dark (`:root`) and light (`[data-theme='light']`) blocks
- [x] Toggle `data-theme="light"` in browser DevTools and verify the computed values switch to the lighter shade variants

Closes: #237