### PR TITLE
feat(sigil): Add elevated and tonal tokens

### DIFF
--- a/packages/sigil/src/primitives/_shadow.scss
+++ b/packages/sigil/src/primitives/_shadow.scss
@@ -1,0 +1,7 @@
+$shadow-elevated:
+    0px 1px 2px oklch(0% 0 0deg / 30%),
+    0px 1px 3px 1px oklch(0% 0 0deg / 15%);
+$shadow-elevated-hover:
+    0px 1px 2px oklch(0% 0 0deg / 30%),
+    0px 2px 6px 2px oklch(0% 0 0deg / 15%);
+$shadow-elevated-active: 0px 1px 2px oklch(0% 0 0deg / 30%);

--- a/packages/sigil/src/semantics/_color.scss
+++ b/packages/sigil/src/semantics/_color.scss
@@ -6,6 +6,7 @@
     --color-surface-default: #{$color-maroon-900};
     --color-surface-raised: #{$color-maroon-800};
     --color-surface-overlay: #{$color-maroon-700};
+    --color-surface-elevated: #{$color-maroon-700};
 
     // Text
     --color-text-primary: #{$color-white};
@@ -35,6 +36,13 @@
     --color-interactive-info-active: #{$color-sky-500};
     --color-interactive-focus-on-primary: #{$color-gold-400};
     --color-interactive-focus-on-secondary: #{$color-maroon-300};
+
+    // Interactive — tonal backgrounds
+    --color-interactive-primary-tonal: #{$color-maroon-800};
+    --color-interactive-danger-tonal: #{$color-red-900};
+    --color-interactive-warning-tonal: #{$color-yellow-900};
+    --color-interactive-success-tonal: #{$color-emerald-900};
+    --color-interactive-info-tonal: #{$color-sky-900};
 }
 
 @mixin light-theme-colors() {
@@ -43,6 +51,7 @@
     --color-surface-default: #{$color-maroon-50};
     --color-surface-raised: #{$color-white};
     --color-surface-overlay: #{$color-white};
+    --color-surface-elevated: #{$color-white};
 
     // Text
     --color-text-primary: #{$color-grey-900};
@@ -72,6 +81,13 @@
     --color-interactive-info-active: #{$color-sky-800};
     --color-interactive-focus-on-primary: #{$color-gold-500};
     --color-interactive-focus-on-secondary: #{$color-maroon-400};
+
+    // Interactive — tonal backgrounds
+    --color-interactive-primary-tonal: #{$color-maroon-100};
+    --color-interactive-danger-tonal: #{$color-red-100};
+    --color-interactive-warning-tonal: #{$color-yellow-100};
+    --color-interactive-success-tonal: #{$color-emerald-100};
+    --color-interactive-info-tonal: #{$color-sky-100};
 }
 
 :root {

--- a/packages/sigil/src/tokens/_color.scss
+++ b/packages/sigil/src/tokens/_color.scss
@@ -5,6 +5,7 @@ $color-surface-subtle: var(--color-surface-subtle, #{$color-maroon-950});
 $color-surface-default: var(--color-surface-default, #{$color-maroon-900});
 $color-surface-raised: var(--color-surface-raised, #{$color-maroon-800});
 $color-surface-overlay: var(--color-surface-overlay, #{$color-maroon-700});
+$color-surface-elevated: var(--color-surface-elevated, #{$color-maroon-700});
 
 // Text
 $color-text-primary: var(--color-text-primary, #{$color-white});
@@ -34,3 +35,10 @@ $color-interactive-info-hover: var(--color-interactive-info-hover, #{$color-sky-
 $color-interactive-info-active: var(--color-interactive-info-active, #{$color-sky-500});
 $color-interactive-focus-on-primary: var(--color-interactive-focus-on-primary, #{$color-gold-400});
 $color-interactive-focus-on-secondary: var(--color-interactive-focus-on-secondary, #{$color-maroon-300});
+
+// Interactive — tonal backgrounds
+$color-interactive-primary-tonal: var(--color-interactive-primary-tonal, #{$color-maroon-800});
+$color-interactive-danger-tonal: var(--color-interactive-danger-tonal, #{$color-red-900});
+$color-interactive-warning-tonal: var(--color-interactive-warning-tonal, #{$color-yellow-900});
+$color-interactive-success-tonal: var(--color-interactive-success-tonal, #{$color-emerald-900});
+$color-interactive-info-tonal: var(--color-interactive-info-tonal, #{$color-sky-900});


### PR DESCRIPTION
## Summary

### Context

The button component (issues #239–#245) requires elevated and tonal appearance variants. Before the button styles can reference design tokens, Sigil must define the underlying values. This PR establishes the token foundation for both appearances.

### Changes

Added a new `primitives/_shadow.scss` file with three box-shadow primitives covering the elevated button's default, hover, and active states (`$shadow-elevated`, `$shadow-elevated-hover`, `$shadow-elevated-active`). Added a semantic `--color-surface-elevated` token to both dark and light theme mixins in `semantics/_color.scss` (dark: `maroon-700`, light: `white`). Added per-intent `--color-interactive-{intent}-tonal` tokens for all five intents (primary, danger, warning, success, info) in both themes, using deep tints in dark mode and light tints in light mode. Added the corresponding SCSS variable wrappers with dark-mode fallbacks in `tokens/_color.scss`.

## Breaking Changes

No breaking changes.

## Test Plan

- [x] Run `pnpm moon run sigil:build` and confirm the build completes without errors
- [x] Verify the new CSS custom properties appear in the compiled `dist/index.css` output

Closes: #238