### PR TITLE
feat(arcane-ui): Implement ButtonComponent inputs and host bindings

### DIFF
--- a/packages/arcane-ui/common/lib/button-appearance.model.ts
+++ b/packages/arcane-ui/common/lib/button-appearance.model.ts
@@ -1,0 +1,19 @@
+/** Visual presentation variants for `ButtonComponent`. Values map to CSS class names on the host. */
+export const ButtonAppearances = {
+    FILLED: 'filled',
+    OUTLINED: 'outlined',
+    GHOST: 'ghost',
+    ELEVATED: 'elevated',
+    TONAL: 'tonal',
+} as const;
+
+/** Union of valid button appearance values derived from {@link ButtonAppearances}. */
+export type ButtonAppearance = (typeof ButtonAppearances)[keyof typeof ButtonAppearances];
+
+/** Appearance applied when no `appearance` input is provided. */
+export const DEFAULT_BUTTON_APPEARANCE: ButtonAppearance = ButtonAppearances.FILLED;
+
+/** Returns the CSS class token for the given appearance, falling back to the default when the value is unrecognized. */
+export function buttonAppearanceAttr(value: ButtonAppearance | ''): ButtonAppearance {
+    return Object.values(ButtonAppearances).find((appearance) => value === appearance) ?? DEFAULT_BUTTON_APPEARANCE;
+}

--- a/packages/arcane-ui/common/lib/button-intent.model.ts
+++ b/packages/arcane-ui/common/lib/button-intent.model.ts
@@ -1,0 +1,19 @@
+/** Semantic color intents for `ButtonComponent`. Values map to CSS class names on the host. */
+export const ButtonIntents = {
+    PRIMARY: 'primary',
+    DANGER: 'danger',
+    WARNING: 'warning',
+    SUCCESS: 'success',
+    INFO: 'info',
+} as const;
+
+/** Union of valid button intent values derived from {@link ButtonIntents}. */
+export type ButtonIntent = (typeof ButtonIntents)[keyof typeof ButtonIntents];
+
+/** Intent applied when no `intent` input is provided. */
+export const DEFAULT_BUTTON_INTENT: ButtonIntent = ButtonIntents.PRIMARY;
+
+/** Returns the CSS class token for the given intent, falling back to the default when the value is unrecognized. */
+export function buttonIntentAttr(value: ButtonIntent | ''): ButtonIntent {
+    return Object.values(ButtonIntents).find((intent) => value === intent) ?? DEFAULT_BUTTON_INTENT;
+}

--- a/packages/arcane-ui/common/lib/button-size.model.ts
+++ b/packages/arcane-ui/common/lib/button-size.model.ts
@@ -1,0 +1,17 @@
+/** Named size tokens for `ButtonComponent`. Values map to CSS class names on the host. */
+export const ButtonSizes = {
+    SMALL: 'sm',
+    MEDIUM: 'md',
+    LARGE: 'lg',
+} as const;
+
+/** Union of valid button size values derived from {@link ButtonSizes}. */
+export type ButtonSize = (typeof ButtonSizes)[keyof typeof ButtonSizes];
+
+/** Size applied when no `size` input is provided. */
+export const DEFAULT_BUTTON_SIZE: ButtonSize = ButtonSizes.MEDIUM;
+
+/** Returns the CSS class token for the given size. */
+export function buttonSizeAttr(value: ButtonSize | ''): ButtonSize {
+    return Object.values(ButtonSizes).find((size) => value === size) ?? DEFAULT_BUTTON_SIZE;
+}

--- a/packages/arcane-ui/common/public-api.ts
+++ b/packages/arcane-ui/common/public-api.ts
@@ -1,3 +1,11 @@
+export {
+    ButtonAppearances,
+    DEFAULT_BUTTON_APPEARANCE,
+    buttonAppearanceAttr,
+    type ButtonAppearance,
+} from './lib/button-appearance.model';
+export { ButtonIntents, DEFAULT_BUTTON_INTENT, buttonIntentAttr, type ButtonIntent } from './lib/button-intent.model';
+export { ButtonSizes, DEFAULT_BUTTON_SIZE, buttonSizeAttr, type ButtonSize } from './lib/button-size.model';
 export { CONFIG_URL } from './lib/config-url.token';
 export { IconSizes, type IconSize } from './lib/icon-size.model';
 export { STORAGE, provideStorage } from './lib/provide-storage';

--- a/packages/arcane-ui/components/lib/button/button.component.scss
+++ b/packages/arcane-ui/components/lib/button/button.component.scss
@@ -1,1 +1,6 @@
 // TODO #241
+:host {
+    &[aria-disabled='true'] {
+        pointer-events: none;
+    }
+}

--- a/packages/arcane-ui/components/lib/button/button.component.scss
+++ b/packages/arcane-ui/components/lib/button/button.component.scss
@@ -1,6 +1,1 @@
 // TODO #241
-:host {
-    &[aria-disabled='true'] {
-        pointer-events: none;
-    }
-}

--- a/packages/arcane-ui/components/lib/button/button.component.spec.ts
+++ b/packages/arcane-ui/components/lib/button/button.component.spec.ts
@@ -1,4 +1,15 @@
-import { Component } from '@angular/core';
+import { Component, signal } from '@angular/core';
+import {
+    ButtonAppearances,
+    ButtonIntents,
+    ButtonSizes,
+    DEFAULT_BUTTON_APPEARANCE,
+    DEFAULT_BUTTON_INTENT,
+    DEFAULT_BUTTON_SIZE,
+    type ButtonAppearance,
+    type ButtonIntent,
+    type ButtonSize,
+} from '@dnd-mapp/arcane-ui/common';
 import { ButtonHarness } from '@dnd-mapp/arcane-ui/components/testing';
 import { setupTestEnvironment } from '@dnd-mapp/arcane-ui/testing';
 import { ButtonComponent } from './button.component';
@@ -6,24 +17,144 @@ import { ButtonComponent } from './button.component';
 describe('ButtonComponent', () => {
     @Component({
         selector: 'dma-test',
-        template: '<button type="button" dma-button>Click</button>',
+        template: `
+            <button
+                dma-button
+                [appearance]="appearance()"
+                [intent]="intent()"
+                [size]="size()"
+                [iconOnly]="iconOnly()"
+                [loading]="loading()"
+                [fullWidth]="fullWidth()"
+            >
+                Click
+            </button>
+        `,
         imports: [ButtonComponent],
     })
-    class TestComponent {}
+    class TestComponent {
+        public readonly appearance = signal<ButtonAppearance | ''>('filled');
+        public readonly intent = signal<ButtonIntent | ''>('primary');
+        public readonly size = signal<ButtonSize | ''>('md');
+        public readonly iconOnly = signal(false);
+        public readonly loading = signal(false);
+        public readonly fullWidth = signal(false);
+    }
 
     async function setupTest() {
-        const { harness } = await setupTestEnvironment({
+        const { fixture, harness } = await setupTestEnvironment({
             testComponent: TestComponent,
             harness: ButtonHarness,
         });
 
         return {
-            harness: harness,
+            component: fixture!.componentInstance,
+            harness: harness!,
         };
     }
 
-    it('can be located via its harness', async () => {
-        const { harness } = await setupTest();
-        expect(harness).toBeDefined();
+    describe('appearance', () => {
+        it.each(Object.values(ButtonAppearances))(
+            'appearance "%s" applies the correct class to the host',
+            async (appearance) => {
+                const { component, harness } = await setupTest();
+                component.appearance.set(appearance);
+
+                expect(await harness.hasAppearance(appearance)).toBe(true);
+
+                for (const other of Object.values(ButtonAppearances).filter((a) => a !== appearance)) {
+                    expect(await harness.hasAppearance(other)).toBe(false);
+                }
+            },
+        );
+
+        it('falls back to the default appearance for unrecognised values', async () => {
+            const { component, harness } = await setupTest();
+            component.appearance.set('');
+
+            expect(await harness.hasAppearance(DEFAULT_BUTTON_APPEARANCE)).toBe(true);
+        });
+    });
+
+    describe('intent', () => {
+        it.each(Object.values(ButtonIntents))('intent "%s" applies the correct class to the host', async (intent) => {
+            const { component, harness } = await setupTest();
+            component.intent.set(intent);
+
+            expect(await harness.hasIntent(intent)).toBe(true);
+
+            for (const other of Object.values(ButtonIntents).filter((i) => i !== intent)) {
+                expect(await harness.hasIntent(other)).toBe(false);
+            }
+        });
+
+        it('falls back to the default intent for unrecognised values', async () => {
+            const { component, harness } = await setupTest();
+            component.intent.set('');
+
+            expect(await harness.hasIntent(DEFAULT_BUTTON_INTENT)).toBe(true);
+        });
+    });
+
+    describe('size', () => {
+        it.each(Object.values(ButtonSizes))('size "%s" applies the correct class to the host', async (size) => {
+            const { component, harness } = await setupTest();
+            component.size.set(size);
+
+            expect(await harness.hasSize(size)).toBe(true);
+
+            for (const other of Object.values(ButtonSizes).filter((s) => s !== size)) {
+                expect(await harness.hasSize(other)).toBe(false);
+            }
+        });
+
+        it('falls back to the default size for unrecognised values', async () => {
+            const { component, harness } = await setupTest();
+            component.size.set('');
+
+            expect(await harness.hasSize(DEFAULT_BUTTON_SIZE)).toBe(true);
+        });
+    });
+
+    describe('iconOnly', () => {
+        it('does not have the icon-only class by default', async () => {
+            const { harness } = await setupTest();
+            expect(await harness.isIconOnly()).toBe(false);
+        });
+
+        it('applies the icon-only class when set to true', async () => {
+            const { component, harness } = await setupTest();
+            component.iconOnly.set(true);
+
+            expect(await harness.isIconOnly()).toBe(true);
+        });
+    });
+
+    describe('loading', () => {
+        it('does not have the loading class by default', async () => {
+            const { harness } = await setupTest();
+            expect(await harness.isLoading()).toBe(false);
+        });
+
+        it('applies the loading class when set to true', async () => {
+            const { component, harness } = await setupTest();
+            component.loading.set(true);
+
+            expect(await harness.isLoading()).toBe(true);
+        });
+    });
+
+    describe('fullWidth', () => {
+        it('does not have the full-width class by default', async () => {
+            const { harness } = await setupTest();
+            expect(await harness.isFullWidth()).toBe(false);
+        });
+
+        it('applies the full-width class when set to true', async () => {
+            const { component, harness } = await setupTest();
+            component.fullWidth.set(true);
+
+            expect(await harness.isFullWidth()).toBe(true);
+        });
     });
 });

--- a/packages/arcane-ui/components/lib/button/button.component.ts
+++ b/packages/arcane-ui/components/lib/button/button.component.ts
@@ -1,9 +1,56 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import {
+    buttonAppearanceAttr,
+    buttonIntentAttr,
+    buttonSizeAttr,
+    DEFAULT_BUTTON_APPEARANCE,
+    DEFAULT_BUTTON_INTENT,
+    DEFAULT_BUTTON_SIZE,
+} from '@dnd-mapp/arcane-ui/common';
 
+/**
+ * Enhances a native `<button>` element with DnD Mapp's design-system appearance,
+ * intent, and size variants.
+ *
+ * Apply as an attribute selector on a `<button>` element:
+ *
+ * @example
+ * ```html
+ * <button dma-button>Label</button>
+ * <button dma-button appearance="outlined" intent="danger" size="sm">Delete</button>
+ * ```
+ */
 @Component({
     selector: 'button[dma-button]',
     templateUrl: './button.component.html',
     styleUrl: './button.component.scss',
     changeDetection: ChangeDetectionStrategy.OnPush,
+    host: {
+        'type': 'button',
+        '[class]': 'this.classNames()',
+        '[class.icon-only]': 'iconOnly()',
+        '[class.loading]': 'loading()',
+        '[class.full-width]': 'fullWidth()',
+    },
 })
-export class ButtonComponent {}
+export class ButtonComponent {
+    /** Visual presentation variant. Defaults to `filled`. */
+    public readonly appearance = input(DEFAULT_BUTTON_APPEARANCE, { transform: buttonAppearanceAttr });
+
+    /** Semantic colour intent. Defaults to `primary`. */
+    public readonly intent = input(DEFAULT_BUTTON_INTENT, { transform: buttonIntentAttr });
+
+    /** Size of the button. Defaults to `md`. */
+    public readonly size = input(DEFAULT_BUTTON_SIZE, { transform: buttonSizeAttr });
+
+    /** When `true`, renders the button as a square icon-only target (no text padding). */
+    public readonly iconOnly = input(false);
+
+    /** When `true`, indicates an in-progress action; applies a loading state class. */
+    public readonly loading = input(false);
+
+    /** When `true`, stretches the button to fill its container's width. */
+    public readonly fullWidth = input(false);
+
+    protected readonly classNames = computed(() => `${this.appearance()} ${this.intent()} ${this.size()}`);
+}

--- a/packages/arcane-ui/components/lib/button/button.stories.ts
+++ b/packages/arcane-ui/components/lib/button/button.stories.ts
@@ -1,9 +1,39 @@
+import { ButtonAppearances, ButtonIntents, ButtonSizes } from '@dnd-mapp/arcane-ui/common';
 import type { Meta, StoryObj } from '@storybook/angular';
 import { ButtonComponent } from './button.component';
 
 const meta: Meta<ButtonComponent> = {
     title: 'Components/Button',
     component: ButtonComponent,
+    argTypes: {
+        appearance: {
+            control: 'select',
+            options: Object.values(ButtonAppearances),
+            description: 'Visual presentation variant of the button.',
+        },
+        intent: {
+            control: 'select',
+            options: Object.values(ButtonIntents),
+            description: 'Semantic colour intent applied to the button.',
+        },
+        size: {
+            control: 'select',
+            options: Object.values(ButtonSizes),
+            description: 'Size of the button.',
+        },
+        iconOnly: {
+            control: 'boolean',
+            description: 'Render the button as a square icon-only target.',
+        },
+        loading: {
+            control: 'boolean',
+            description: 'Indicates an in-progress action.',
+        },
+        fullWidth: {
+            control: 'boolean',
+            description: 'Stretch the button to fill its container.',
+        },
+    },
 };
 
 export default meta;
@@ -11,3 +41,15 @@ export default meta;
 type Story = StoryObj<ButtonComponent>;
 
 export const Default: Story = {};
+
+export const IconOnly: Story = {
+    args: { iconOnly: true },
+};
+
+export const Loading: Story = {
+    args: { loading: true },
+};
+
+export const FullWidth: Story = {
+    args: { fullWidth: true },
+};

--- a/packages/arcane-ui/components/testing/lib/button.harness.ts
+++ b/packages/arcane-ui/components/testing/lib/button.harness.ts
@@ -1,5 +1,37 @@
 import { ComponentHarness } from '@angular/cdk/testing';
+import {
+    buttonAppearanceAttr,
+    buttonIntentAttr,
+    buttonSizeAttr,
+    type ButtonAppearance,
+    type ButtonIntent,
+    type ButtonSize,
+} from '@dnd-mapp/arcane-ui/common';
 
 export class ButtonHarness extends ComponentHarness {
     public static readonly hostSelector = 'button[dma-button]';
+
+    public async hasAppearance(appearance: ButtonAppearance): Promise<boolean> {
+        return (await this.host()).hasClass(buttonAppearanceAttr(appearance));
+    }
+
+    public async hasIntent(intent: ButtonIntent): Promise<boolean> {
+        return (await this.host()).hasClass(buttonIntentAttr(intent));
+    }
+
+    public async hasSize(size: ButtonSize): Promise<boolean> {
+        return (await this.host()).hasClass(buttonSizeAttr(size));
+    }
+
+    public async isIconOnly(): Promise<boolean> {
+        return (await this.host()).hasClass('icon-only');
+    }
+
+    public async isLoading(): Promise<boolean> {
+        return (await this.host()).hasClass('loading');
+    }
+
+    public async isFullWidth(): Promise<boolean> {
+        return (await this.host()).hasClass('full-width');
+    }
 }


### PR DESCRIPTION
## Summary

### Context

`ButtonComponent` was scaffolded as a shell with no inputs. Without inputs wired to host CSS classes, consumers had no way to configure the component's visual presentation — appearance variant, semantic colour intent, size, icon-only mode, loading state, or full-width stretch.

### Changes

Three model files were added to the `arcane-ui/common` entry point — one each for appearance, intent, and size. Each model exports a `const` value map, a derived union type, a default constant, and a transform function (`buttonAppearanceAttr`, `buttonIntentAttr`, `buttonSizeAttr`). These transform functions are passed directly to Angular's `input()` `transform` option, so unrecognised attribute values fall back to the default automatically.

`ButtonComponent` gained six `input()` signal declarations. The three string inputs use `{ transform: fn }` from the new models; a `classNames` computed signal combines them for the host `[class]` binding. The three boolean inputs (`iconOnly`, `loading`, `fullWidth`) each drive a separate `[class.*]` host binding. `type="button"` is enforced statically via host metadata. Styling for `aria-disabled` is deferred to #241.

`ButtonHarness` was extended with typed inspection helpers and the test suite covers correct class application for every valid value as well as fallback behaviour for unrecognised inputs. Storybook stories and `argTypes` controls were added for all six inputs.

## Test Plan

- [x] `pnpm moon run arcane-ui:test-ci` passes with no failures
- [x] Open Storybook → Components/Button — controls for all six inputs are visible and functional
- [ ] Verify that changing `appearance`, `intent`, and `size` in Storybook applies the correct CSS class on the host element

Closes: #240