### PR TITLE
feat(arcane-ui): Implement ButtonComponent SCSS styles and tokens

### DIFF
--- a/packages/arcane-ui/components/lib/button/button.component.html
+++ b/packages/arcane-ui/components/lib/button/button.component.html
@@ -1,1 +1,2 @@
-<ng-content />
+<div class="content"><ng-content /></div>
+<dma-icon-spinner />

--- a/packages/arcane-ui/components/lib/button/button.component.scss
+++ b/packages/arcane-ui/components/lib/button/button.component.scss
@@ -1,1 +1,471 @@
-// TODO #241
+@use '@dnd-mapp/sigil/primitives/radius' as *;
+@use '@dnd-mapp/sigil/primitives/shadow' as *;
+@use '@dnd-mapp/sigil/primitives/spacing' as *;
+@use '@dnd-mapp/sigil/tokens/color' as *;
+@use '@dnd-mapp/sigil/tokens/typography' as *;
+
+// ── Component tokens ────────────────────────────────────────────────────────
+
+:host {
+    --dma-button-bg: transparent;
+    --dma-button-text: #{$color-text-primary};
+    --dma-button-border: transparent;
+    --dma-button-shadow: none;
+    --dma-button-padding: #{$spacing-2} #{$spacing-4};
+    --dma-button-font-size: #{$typography-size-sm};
+    --dma-button-min-height: 2.25rem;
+
+    cursor: pointer;
+
+    display: inline-grid;
+    place-items: center;
+
+    min-height: var(--dma-button-min-height);
+    padding: var(--dma-button-padding);
+    border: 1px solid var(--dma-button-border);
+    border-radius: $radius-md;
+
+    font-family: #{$typography-font-body};
+    font-size: var(--dma-button-font-size);
+    font-weight: #{$typography-weight-medium};
+    line-height: #{$typography-line-height-tight};
+    color: var(--dma-button-text);
+    text-decoration: none;
+    white-space: nowrap;
+
+    background-color: var(--dma-button-bg);
+    box-shadow: var(--dma-button-shadow);
+
+    transition:
+        background-color 150ms ease,
+        border-color 150ms ease,
+        box-shadow 150ms ease,
+        color 150ms ease;
+
+    .content,
+    dma-icon-spinner {
+        display: flex;
+        grid-area: 1 / 1;
+        align-items: center;
+        justify-content: center;
+    }
+
+    dma-icon-spinner {
+        visibility: hidden;
+    }
+
+    &:focus-visible {
+        outline: 2px solid #{$color-interactive-focus-on-primary};
+        outline-offset: 2px;
+    }
+
+    &:disabled,
+    &.loading {
+        pointer-events: none;
+        cursor: not-allowed;
+        opacity: 0.5;
+    }
+}
+
+// ── Loading state ────────────────────────────────────────────────────────────
+
+:host(.loading) {
+    .content {
+        visibility: hidden;
+    }
+
+    dma-icon-spinner {
+        visibility: visible;
+    }
+}
+
+// ── Size scale ───────────────────────────────────────────────────────────────
+
+:host(.sm) {
+    --dma-button-padding: #{$spacing-1} #{$spacing-3};
+    --dma-button-font-size: #{$typography-size-xs};
+    --dma-button-min-height: 1.75rem;
+}
+
+:host(.lg) {
+    --dma-button-padding: #{$spacing-3} #{$spacing-5};
+    --dma-button-font-size: #{$typography-size-md};
+    --dma-button-min-height: 2.75rem;
+}
+
+// ── Modifier classes ─────────────────────────────────────────────────────────
+
+:host(.full-width) {
+    width: 100%;
+}
+
+:host(.icon-only) {
+    --dma-button-icon-only-padding: #{$spacing-2};
+
+    aspect-ratio: 1 / 1;
+    padding: var(--dma-button-icon-only-padding);
+}
+
+:host(.icon-only.sm) {
+    --dma-button-icon-only-padding: #{$spacing-1};
+}
+
+:host(.icon-only.lg) {
+    --dma-button-icon-only-padding: #{$spacing-3};
+}
+
+// ── Appearance × Intent ───────────────────────────────────────────────────────
+// filled — solid intent background, on-interactive text color
+
+:host(.filled.primary) {
+    --dma-button-bg: #{$color-interactive-primary};
+    --dma-button-text: #{$color-text-on-interactive};
+
+    &:hover:not(:disabled, .loading) {
+        --dma-button-bg: #{$color-interactive-primary-hover};
+    }
+
+    &:active:not(:disabled, .loading) {
+        --dma-button-bg: #{$color-interactive-primary-active};
+    }
+}
+
+:host(.filled.danger) {
+    --dma-button-bg: #{$color-interactive-danger};
+    --dma-button-text: #{$color-text-on-interactive};
+
+    &:hover:not(:disabled, .loading) {
+        --dma-button-bg: #{$color-interactive-danger-hover};
+    }
+
+    &:active:not(:disabled, .loading) {
+        --dma-button-bg: #{$color-interactive-danger-active};
+    }
+}
+
+:host(.filled.warning) {
+    --dma-button-bg: #{$color-interactive-warning};
+    --dma-button-text: #{$color-text-on-interactive};
+
+    &:hover:not(:disabled, .loading) {
+        --dma-button-bg: #{$color-interactive-warning-hover};
+    }
+
+    &:active:not(:disabled, .loading) {
+        --dma-button-bg: #{$color-interactive-warning-active};
+    }
+}
+
+:host(.filled.success) {
+    --dma-button-bg: #{$color-interactive-success};
+    --dma-button-text: #{$color-text-on-interactive};
+
+    &:hover:not(:disabled, .loading) {
+        --dma-button-bg: #{$color-interactive-success-hover};
+    }
+
+    &:active:not(:disabled, .loading) {
+        --dma-button-bg: #{$color-interactive-success-active};
+    }
+}
+
+:host(.filled.info) {
+    --dma-button-bg: #{$color-interactive-info};
+    --dma-button-text: #{$color-text-on-interactive};
+
+    &:hover:not(:disabled, .loading) {
+        --dma-button-bg: #{$color-interactive-info-hover};
+    }
+
+    &:active:not(:disabled, .loading) {
+        --dma-button-bg: #{$color-interactive-info-active};
+    }
+}
+
+// outlined — transparent background, intent-coloured border and text
+
+:host(.outlined.primary) {
+    --dma-button-border: #{$color-interactive-primary};
+    --dma-button-text: #{$color-interactive-primary};
+
+    &:hover:not(:disabled, .loading) {
+        --dma-button-bg: #{$color-interactive-primary-tonal};
+    }
+
+    &:active:not(:disabled, .loading) {
+        --dma-button-bg: #{$color-interactive-primary-active};
+        --dma-button-text: #{$color-text-on-interactive};
+    }
+}
+
+:host(.outlined.danger) {
+    --dma-button-border: #{$color-interactive-danger};
+    --dma-button-text: #{$color-interactive-danger};
+
+    &:hover:not(:disabled, .loading) {
+        --dma-button-bg: #{$color-interactive-danger-tonal};
+    }
+
+    &:active:not(:disabled, .loading) {
+        --dma-button-bg: #{$color-interactive-danger-active};
+        --dma-button-text: #{$color-text-on-interactive};
+    }
+}
+
+:host(.outlined.warning) {
+    --dma-button-border: #{$color-interactive-warning};
+    --dma-button-text: #{$color-interactive-warning};
+
+    &:hover:not(:disabled, .loading) {
+        --dma-button-bg: #{$color-interactive-warning-tonal};
+    }
+
+    &:active:not(:disabled, .loading) {
+        --dma-button-bg: #{$color-interactive-warning-active};
+        --dma-button-text: #{$color-text-on-interactive};
+    }
+}
+
+:host(.outlined.success) {
+    --dma-button-border: #{$color-interactive-success};
+    --dma-button-text: #{$color-interactive-success};
+
+    &:hover:not(:disabled, .loading) {
+        --dma-button-bg: #{$color-interactive-success-tonal};
+    }
+
+    &:active:not(:disabled, .loading) {
+        --dma-button-bg: #{$color-interactive-success-active};
+        --dma-button-text: #{$color-text-on-interactive};
+    }
+}
+
+:host(.outlined.info) {
+    --dma-button-border: #{$color-interactive-info};
+    --dma-button-text: #{$color-interactive-info};
+
+    &:hover:not(:disabled, .loading) {
+        --dma-button-bg: #{$color-interactive-info-tonal};
+    }
+
+    &:active:not(:disabled, .loading) {
+        --dma-button-bg: #{$color-interactive-info-active};
+        --dma-button-text: #{$color-text-on-interactive};
+    }
+}
+
+// ghost — no border, intent-coloured text, tonal hover
+
+:host(.ghost.primary) {
+    --dma-button-text: #{$color-interactive-primary};
+
+    &:hover:not(:disabled, .loading) {
+        --dma-button-bg: #{$color-interactive-primary-tonal};
+    }
+
+    &:active:not(:disabled, .loading) {
+        --dma-button-bg: #{$color-interactive-primary-active};
+        --dma-button-text: #{$color-text-on-interactive};
+    }
+}
+
+:host(.ghost.danger) {
+    --dma-button-text: #{$color-interactive-danger};
+
+    &:hover:not(:disabled, .loading) {
+        --dma-button-bg: #{$color-interactive-danger-tonal};
+    }
+
+    &:active:not(:disabled, .loading) {
+        --dma-button-bg: #{$color-interactive-danger-active};
+        --dma-button-text: #{$color-text-on-interactive};
+    }
+}
+
+:host(.ghost.warning) {
+    --dma-button-text: #{$color-interactive-warning};
+
+    &:hover:not(:disabled, .loading) {
+        --dma-button-bg: #{$color-interactive-warning-tonal};
+    }
+
+    &:active:not(:disabled, .loading) {
+        --dma-button-bg: #{$color-interactive-warning-active};
+        --dma-button-text: #{$color-text-on-interactive};
+    }
+}
+
+:host(.ghost.success) {
+    --dma-button-text: #{$color-interactive-success};
+
+    &:hover:not(:disabled, .loading) {
+        --dma-button-bg: #{$color-interactive-success-tonal};
+    }
+
+    &:active:not(:disabled, .loading) {
+        --dma-button-bg: #{$color-interactive-success-active};
+        --dma-button-text: #{$color-text-on-interactive};
+    }
+}
+
+:host(.ghost.info) {
+    --dma-button-text: #{$color-interactive-info};
+
+    &:hover:not(:disabled, .loading) {
+        --dma-button-bg: #{$color-interactive-info-tonal};
+    }
+
+    &:active:not(:disabled, .loading) {
+        --dma-button-bg: #{$color-interactive-info-active};
+        --dma-button-text: #{$color-text-on-interactive};
+    }
+}
+
+// tonal — intent tonal background, intent-coloured text
+
+:host(.tonal.primary) {
+    --dma-button-bg: #{$color-interactive-primary-tonal};
+    --dma-button-text: #{$color-interactive-primary};
+
+    &:hover:not(:disabled, .loading) {
+        --dma-button-bg: #{$color-interactive-primary-hover};
+        --dma-button-text: #{$color-text-on-interactive};
+    }
+
+    &:active:not(:disabled, .loading) {
+        --dma-button-bg: #{$color-interactive-primary-active};
+        --dma-button-text: #{$color-text-on-interactive};
+    }
+}
+
+:host(.tonal.danger) {
+    --dma-button-bg: #{$color-interactive-danger-tonal};
+    --dma-button-text: #{$color-interactive-danger};
+
+    &:hover:not(:disabled, .loading) {
+        --dma-button-bg: #{$color-interactive-danger-hover};
+        --dma-button-text: #{$color-text-on-interactive};
+    }
+
+    &:active:not(:disabled, .loading) {
+        --dma-button-bg: #{$color-interactive-danger-active};
+        --dma-button-text: #{$color-text-on-interactive};
+    }
+}
+
+:host(.tonal.warning) {
+    --dma-button-bg: #{$color-interactive-warning-tonal};
+    --dma-button-text: #{$color-interactive-warning};
+
+    &:hover:not(:disabled, .loading) {
+        --dma-button-bg: #{$color-interactive-warning-hover};
+        --dma-button-text: #{$color-text-on-interactive};
+    }
+
+    &:active:not(:disabled, .loading) {
+        --dma-button-bg: #{$color-interactive-warning-active};
+        --dma-button-text: #{$color-text-on-interactive};
+    }
+}
+
+:host(.tonal.success) {
+    --dma-button-bg: #{$color-interactive-success-tonal};
+    --dma-button-text: #{$color-interactive-success};
+
+    &:hover:not(:disabled, .loading) {
+        --dma-button-bg: #{$color-interactive-success-hover};
+        --dma-button-text: #{$color-text-on-interactive};
+    }
+
+    &:active:not(:disabled, .loading) {
+        --dma-button-bg: #{$color-interactive-success-active};
+        --dma-button-text: #{$color-text-on-interactive};
+    }
+}
+
+:host(.tonal.info) {
+    --dma-button-bg: #{$color-interactive-info-tonal};
+    --dma-button-text: #{$color-interactive-info};
+
+    &:hover:not(:disabled, .loading) {
+        --dma-button-bg: #{$color-interactive-info-hover};
+        --dma-button-text: #{$color-text-on-interactive};
+    }
+
+    &:active:not(:disabled, .loading) {
+        --dma-button-bg: #{$color-interactive-info-active};
+        --dma-button-text: #{$color-text-on-interactive};
+    }
+}
+
+// elevated — surface-elevated background, intent-coloured text, shadow
+
+:host(.elevated.primary) {
+    --dma-button-bg: #{$color-surface-elevated};
+    --dma-button-shadow: #{$shadow-elevated};
+    --dma-button-text: #{$color-interactive-primary};
+
+    &:hover:not(:disabled, .loading) {
+        --dma-button-shadow: #{$shadow-elevated-hover};
+    }
+
+    &:active:not(:disabled, .loading) {
+        --dma-button-shadow: #{$shadow-elevated-active};
+    }
+}
+
+:host(.elevated.danger) {
+    --dma-button-bg: #{$color-surface-elevated};
+    --dma-button-shadow: #{$shadow-elevated};
+    --dma-button-text: #{$color-interactive-danger};
+
+    &:hover:not(:disabled, .loading) {
+        --dma-button-shadow: #{$shadow-elevated-hover};
+    }
+
+    &:active:not(:disabled, .loading) {
+        --dma-button-shadow: #{$shadow-elevated-active};
+    }
+}
+
+:host(.elevated.warning) {
+    --dma-button-bg: #{$color-surface-elevated};
+    --dma-button-shadow: #{$shadow-elevated};
+    --dma-button-text: #{$color-interactive-warning};
+
+    &:hover:not(:disabled, .loading) {
+        --dma-button-shadow: #{$shadow-elevated-hover};
+    }
+
+    &:active:not(:disabled, .loading) {
+        --dma-button-shadow: #{$shadow-elevated-active};
+    }
+}
+
+:host(.elevated.success) {
+    --dma-button-bg: #{$color-surface-elevated};
+    --dma-button-shadow: #{$shadow-elevated};
+    --dma-button-text: #{$color-interactive-success};
+
+    &:hover:not(:disabled, .loading) {
+        --dma-button-shadow: #{$shadow-elevated-hover};
+    }
+
+    &:active:not(:disabled, .loading) {
+        --dma-button-shadow: #{$shadow-elevated-active};
+    }
+}
+
+:host(.elevated.info) {
+    --dma-button-bg: #{$color-surface-elevated};
+    --dma-button-shadow: #{$shadow-elevated};
+    --dma-button-text: #{$color-interactive-info};
+
+    &:hover:not(:disabled, .loading) {
+        --dma-button-shadow: #{$shadow-elevated-hover};
+    }
+
+    &:active:not(:disabled, .loading) {
+        --dma-button-shadow: #{$shadow-elevated-active};
+    }
+}

--- a/packages/arcane-ui/components/lib/button/button.component.ts
+++ b/packages/arcane-ui/components/lib/button/button.component.ts
@@ -7,6 +7,7 @@ import {
     DEFAULT_BUTTON_INTENT,
     DEFAULT_BUTTON_SIZE,
 } from '@dnd-mapp/arcane-ui/common';
+import { SpinnerIconComponent } from '@dnd-mapp/arcane-ui/icons';
 
 /**
  * Enhances a native `<button>` element with DnD Mapp's design-system appearance,
@@ -22,6 +23,7 @@ import {
  */
 @Component({
     selector: 'button[dma-button]',
+    imports: [SpinnerIconComponent],
     templateUrl: './button.component.html',
     styleUrl: './button.component.scss',
     changeDetection: ChangeDetectionStrategy.OnPush,
@@ -52,5 +54,6 @@ export class ButtonComponent {
     /** When `true`, stretches the button to fill its container's width. */
     public readonly fullWidth = input(false);
 
+    /** Combines appearance, intent, and size into the host's `[class]` binding. */
     protected readonly classNames = computed(() => `${this.appearance()} ${this.intent()} ${this.size()}`);
 }

--- a/packages/arcane-ui/moon.yml
+++ b/packages/arcane-ui/moon.yml
@@ -28,6 +28,8 @@ fileGroups:
 tasks:
     build:
         command: 'pnpm build'
+        deps:
+            - 'sigil:build'
         inputs:
             - '**/*.{ts,html,scss}'
             - '**/ng-package.json'
@@ -48,6 +50,8 @@ tasks:
 
     storybook-start:
         command: 'pnpm storybook-start'
+        deps:
+            - 'sigil:build'
         preset: 'server'
 
     storybook-build:
@@ -71,6 +75,7 @@ tasks:
         command: 'pnpm test-ci'
         deps:
             - 'root:playwright-install'
+            - 'sigil:build'
         outputs:
             - 'coverage/**'
             - 'reports/**'
@@ -83,6 +88,7 @@ tasks:
         preset: 'server'
         deps:
             - 'root:playwright-install'
+            - 'sigil:build'
 
     lint-css:
         command: 'pnpm lint-css --aei'

--- a/packages/sigil/src/semantics/_color.scss
+++ b/packages/sigil/src/semantics/_color.scss
@@ -25,6 +25,8 @@
     --color-interactive-primary-hover: #{$color-maroon-300};
     --color-interactive-primary-active: #{$color-maroon-500};
     --color-interactive-danger: #{$color-red-400};
+    --color-interactive-danger-hover: #{$color-red-300};
+    --color-interactive-danger-active: #{$color-red-500};
     --color-interactive-warning: #{$color-yellow-400};
     --color-interactive-warning-hover: #{$color-yellow-300};
     --color-interactive-warning-active: #{$color-yellow-500};
@@ -70,6 +72,8 @@
     --color-interactive-primary-hover: #{$color-maroon-700};
     --color-interactive-primary-active: #{$color-maroon-800};
     --color-interactive-danger: #{$color-red-600};
+    --color-interactive-danger-hover: #{$color-red-700};
+    --color-interactive-danger-active: #{$color-red-800};
     --color-interactive-warning: #{$color-yellow-600};
     --color-interactive-warning-hover: #{$color-yellow-700};
     --color-interactive-warning-active: #{$color-yellow-800};

--- a/packages/sigil/src/tokens/_color.scss
+++ b/packages/sigil/src/tokens/_color.scss
@@ -24,6 +24,8 @@ $color-interactive-primary: var(--color-interactive-primary, #{$color-maroon-400
 $color-interactive-primary-hover: var(--color-interactive-primary-hover, #{$color-maroon-300});
 $color-interactive-primary-active: var(--color-interactive-primary-active, #{$color-maroon-500});
 $color-interactive-danger: var(--color-interactive-danger, #{$color-red-400});
+$color-interactive-danger-hover: var(--color-interactive-danger-hover, #{$color-red-300});
+$color-interactive-danger-active: var(--color-interactive-danger-active, #{$color-red-500});
 $color-interactive-warning: var(--color-interactive-warning, #{$color-yellow-400});
 $color-interactive-warning-hover: var(--color-interactive-warning-hover, #{$color-yellow-300});
 $color-interactive-warning-active: var(--color-interactive-warning-active, #{$color-yellow-500});


### PR DESCRIPTION
## Summary

### Context

ButtonComponent had full Angular signal inputs for appearance, intent, size, iconOnly, loading, and fullWidth, but its SCSS file was empty. The Sigil design token layer was also missing hover and active interactive color tokens for the `danger` intent, leaving it inconsistent with the other four intents.

### Changes

Adds `--color-interactive-danger-hover` and `--color-interactive-danger-active` semantic tokens and their corresponding SCSS token variables to Sigil, matching the pattern already established for primary, warning, success, and info intents.

Wires `sigil:build` as an explicit moon task dependency on `build`, `test-ci`, `test`, `storybook-start`, and `storybook-build` in arcane-ui, so sigil's dist output is always available before arcane-ui compiles.

Implements the full ButtonComponent SCSS: defines `--dma-button-*` component tokens (background, text, border, shadow, padding, font-size, min-height) on `:host`, applies a three-step size scale (sm/md/lg), icon-only square mode, full-width stretch, and a loading state that replaces the label with a `SpinnerIconComponent` without resizing the button (CSS grid overlap technique). All 25 appearance × intent combinations (filled, outlined, ghost, tonal, elevated × primary, danger, warning, success, info) are implemented with hover and active state overrides consuming Sigil semantic tokens.

## Breaking Changes

## Test Plan

- [x] Run `pnpm moon run arcane-ui:test-ci` — all 57 tests pass with 100% coverage
- [x] Open Storybook (`pnpm moon run arcane-ui:storybook-start`) and verify all five appearance variants render correctly for each intent
- [x] Verify size scale (sm, md, lg) changes padding and font size as expected
- [x] Verify `iconOnly` produces a square button at each size
- [x] Verify `fullWidth` stretches the button to fill its container
- [ ] Toggle `loading` — label disappears and spinner appears; button dimensions stay the same
- [x] Confirm hover and active states produce visible color/shadow changes for all appearance × intent combinations
- [x] Check both dark and light themes

Closes: #241