### PR TITLE
feat(arcane-ui): Add shared icon infrastructure

### DIFF
--- a/packages/arcane-ui/icons/_icon-base.scss
+++ b/packages/arcane-ui/icons/_icon-base.scss
@@ -1,0 +1,38 @@
+@mixin icon-base {
+    :host {
+        display: inline-flex;
+        width: 1em;
+        height: 1em;
+
+        &.xs {
+            width: var(--dma-icon-size-xs, 0.75rem);
+            height: var(--dma-icon-size-xs, 0.75rem);
+        }
+
+        &.sm {
+            width: var(--dma-icon-size-sm, 1rem);
+            height: var(--dma-icon-size-sm, 1rem);
+        }
+
+        &.md {
+            width: var(--dma-icon-size-md, 1.25rem);
+            height: var(--dma-icon-size-md, 1.25rem);
+        }
+
+        &.lg {
+            width: var(--dma-icon-size-lg, 1.5rem);
+            height: var(--dma-icon-size-lg, 1.5rem);
+        }
+
+        &.xl {
+            width: var(--dma-icon-size-xl, 1.75rem);
+            height: var(--dma-icon-size-xl, 1.75rem);
+        }
+    }
+
+    svg {
+        width: 100%;
+        height: 100%;
+        fill: currentcolor;
+    }
+}

--- a/packages/arcane-ui/icons/lib/icon.directive.ts
+++ b/packages/arcane-ui/icons/lib/icon.directive.ts
@@ -1,0 +1,28 @@
+import { Directive, input } from '@angular/core';
+import { type IconSize } from '@dnd-mapp/arcane-ui/common';
+
+/**
+ * Shared structural directive applied to all icon components via `hostDirectives`.
+ *
+ * Handles two concerns common to every icon:
+ * - Marks the host element as `aria-hidden="true"` so screen readers skip decorative icons.
+ * - Applies the active {@link IconSize} token as a CSS class on the host, which the
+ *   `icon-base` SCSS mixin uses to set explicit dimensions.
+ *
+ * @example
+ * ```ts
+ * // In an icon component:
+ * hostDirectives: [{ directive: IconDirective, inputs: ['size'] }]
+ * ```
+ */
+@Directive({
+    selector: '[dmaIcon]',
+    host: {
+        'aria-hidden': 'true',
+        '[class]': 'size()',
+    },
+})
+export class IconDirective {
+    /** Sets the dimensions of the icon using a named size token. Omit to scale with the surrounding font size (1em). */
+    public readonly size = input<IconSize>();
+}

--- a/packages/arcane-ui/icons/lib/spinner/spinner-icon.component.scss
+++ b/packages/arcane-ui/icons/lib/spinner/spinner-icon.component.scss
@@ -1,40 +1,8 @@
+@use '../../_icon-base' as icons;
+
+@include icons.icon-base;
+
 :host {
-    display: inline-flex;
-
-    width: 1em;
-    height: 1em;
-
     animation: dma-spin var(--dma-animation-spin-duration, 0.8s) linear infinite;
     animation-play-state: var(--dma-animation-play-state, running);
-
-    &.xs {
-        width: var(--dma-icon-size-xs, 0.75rem);
-        height: var(--dma-icon-size-xs, 0.75rem);
-    }
-
-    &.sm {
-        width: var(--dma-icon-size-sm, 1rem);
-        height: var(--dma-icon-size-sm, 1rem);
-    }
-
-    &.md {
-        width: var(--dma-icon-size-md, 1.25rem);
-        height: var(--dma-icon-size-md, 1.25rem);
-    }
-
-    &.lg {
-        width: var(--dma-icon-size-lg, 1.5rem);
-        height: var(--dma-icon-size-lg, 1.5rem);
-    }
-
-    &.xl {
-        width: var(--dma-icon-size-xl, 1.75rem);
-        height: var(--dma-icon-size-xl, 1.75rem);
-    }
-}
-
-svg {
-    width: 100%;
-    height: 100%;
-    fill: currentcolor;
 }

--- a/packages/arcane-ui/icons/lib/spinner/spinner-icon.component.ts
+++ b/packages/arcane-ui/icons/lib/spinner/spinner-icon.component.ts
@@ -1,5 +1,5 @@
-import { ChangeDetectionStrategy, Component, input } from '@angular/core';
-import { type IconSize } from '@dnd-mapp/arcane-ui/common';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { IconDirective } from '../icon.directive';
 
 /**
  * Animated spinner icon that indicates a loading or in-progress state.
@@ -21,12 +21,6 @@ import { type IconSize } from '@dnd-mapp/arcane-ui/common';
     templateUrl: `./spinner-icon.component.html`,
     styleUrl: './spinner-icon.component.scss',
     changeDetection: ChangeDetectionStrategy.OnPush,
-    host: {
-        'aria-hidden': 'true',
-        '[class]': 'size()',
-    },
+    hostDirectives: [{ directive: IconDirective, inputs: ['size'] }],
 })
-export class SpinnerIconComponent {
-    /** Sets the dimensions of the icon using a named size token. Omit to scale with the surrounding font size (1em). */
-    public readonly size = input<IconSize>();
-}
+export class SpinnerIconComponent {}

--- a/packages/arcane-ui/icons/public-api.ts
+++ b/packages/arcane-ui/icons/public-api.ts
@@ -1,1 +1,2 @@
+export { IconDirective } from './lib/icon.directive';
 export { SpinnerIconComponent } from './lib/spinner/spinner-icon.component';

--- a/packages/arcane-ui/icons/testing/lib/base-icon.harness.ts
+++ b/packages/arcane-ui/icons/testing/lib/base-icon.harness.ts
@@ -1,0 +1,18 @@
+import { ComponentHarness } from '@angular/cdk/testing';
+import { type IconSize } from '@dnd-mapp/arcane-ui/common';
+
+export abstract class BaseIconHarness extends ComponentHarness {
+    protected readonly svgLocator = this.locatorForAll('svg');
+
+    public async isAriaHidden(): Promise<boolean> {
+        return (await (await this.host()).getAttribute('aria-hidden')) === 'true';
+    }
+
+    public async hasSize(size: IconSize): Promise<boolean> {
+        return (await this.host()).hasClass(size);
+    }
+
+    public async hasSvg(): Promise<boolean> {
+        return (await this.svgLocator()).length > 0;
+    }
+}

--- a/packages/arcane-ui/icons/testing/lib/spinner-icon.harness.ts
+++ b/packages/arcane-ui/icons/testing/lib/spinner-icon.harness.ts
@@ -1,18 +1,5 @@
-import { ComponentHarness } from '@angular/cdk/testing';
-import { type IconSize } from '@dnd-mapp/arcane-ui/common';
+import { BaseIconHarness } from './base-icon.harness';
 
-export class SpinnerIconHarness extends ComponentHarness {
+export class SpinnerIconHarness extends BaseIconHarness {
     public static readonly hostSelector = 'dma-icon-spinner';
-
-    public async isAriaHidden(): Promise<boolean> {
-        return (await (await this.host()).getAttribute('aria-hidden')) === 'true';
-    }
-
-    public async hasSize(size: IconSize): Promise<boolean> {
-        return (await this.host()).hasClass(size);
-    }
-
-    public async hasSvg(): Promise<boolean> {
-        return (await this.locatorForAll('svg')()).length > 0;
-    }
 }

--- a/packages/arcane-ui/icons/testing/public-api.ts
+++ b/packages/arcane-ui/icons/testing/public-api.ts
@@ -1,1 +1,2 @@
+export { BaseIconHarness } from './lib/base-icon.harness';
 export { SpinnerIconHarness } from './lib/spinner-icon.harness';


### PR DESCRIPTION
## Summary

### Context

Icon components each repeat the same `size` input, `aria-hidden` host binding, and sizing CSS. As the icon library grows, this duplication would compound. The issue asks for shared infrastructure that all icon components can inherit.

### Changes

Adds three new building blocks to the `arcane-ui/icons` entry point:

- `IconDirective` — a structural directive applied via `hostDirectives` that owns the `size` signal input, the `aria-hidden="true"` host attribute, and the `[class]` binding that maps the active size token to a CSS class.
- `_icon-base.scss` — a SCSS mixin that owns the `display: inline-flex` rule, the default `1em` dimensions, the five named-size override classes (`xs`–`xl`), and the `fill: currentcolor` SVG rule.
- `BaseIconHarness` — an abstract CDK harness class that owns the `isAriaHidden`, `hasSize`, and `hasSvg` test helpers.

`SpinnerIconComponent` is migrated to consume `IconDirective` via `hostDirectives` and include `icon-base` via the SCSS mixin, removing the duplicated code it previously held directly. `SpinnerIconHarness` now extends `BaseIconHarness` and retains only its `hostSelector`.

Both `IconDirective` and `BaseIconHarness` are exported from their respective public APIs so future icon components and harnesses can consume them.

## Test Plan

- [x] Run `pnpm moon run arcane-ui:test-ci` — all 57 tests pass.
- [x] Run `pnpm moon run arcane-ui:lint-ts arcane-ui:lint-css` — no errors or warnings.
- [x] Confirm `SpinnerIconComponent` still renders correctly in Storybook.

Closes: #271