### PR TITLE
feat(arcane-ui): Add TrashIconComponent

### DIFF
--- a/packages/arcane-ui/icons/lib/trash/trash-icon.component.html
+++ b/packages/arcane-ui/icons/lib/trash/trash-icon.component.html
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640">
+    <!--!Font Awesome Free v7.2.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2026 Fonticons, Inc.-->
+    <path
+        d="M232.7 69.9L224 96L128 96C110.3 96 96 110.3 96 128C96 145.7 110.3 160 128 160L512 160C529.7 160 544 145.7 544 128C544 110.3 529.7 96 512 96L416 96L407.3 69.9C402.9 56.8 390.7 48 376.9 48L263.1 48C249.3 48 237.1 56.8 232.7 69.9zM512 208L128 208L149.1 531.1C150.7 556.4 171.7 576 197 576L443 576C468.3 576 489.3 556.4 490.9 531.1L512 208z"
+    />
+</svg>

--- a/packages/arcane-ui/icons/lib/trash/trash-icon.component.scss
+++ b/packages/arcane-ui/icons/lib/trash/trash-icon.component.scss
@@ -1,0 +1,3 @@
+@use '../../_icon-base' as icons;
+
+@include icons.icon-base;

--- a/packages/arcane-ui/icons/lib/trash/trash-icon.component.spec.ts
+++ b/packages/arcane-ui/icons/lib/trash/trash-icon.component.spec.ts
@@ -1,0 +1,53 @@
+import { Component, signal } from '@angular/core';
+import { type IconSize, IconSizes } from '@dnd-mapp/arcane-ui/common';
+import { TrashIconHarness } from '@dnd-mapp/arcane-ui/icons/testing';
+import { setupTestEnvironment } from '@dnd-mapp/arcane-ui/testing';
+import { TrashIconComponent } from './trash-icon.component';
+
+describe('TrashIconComponent', () => {
+    @Component({
+        selector: 'dma-test',
+        template: '<dma-icon-trash [size]="size()" />',
+        imports: [TrashIconComponent],
+    })
+    class TestComponent {
+        public readonly size = signal<IconSize | undefined>(undefined);
+    }
+
+    async function setupTest() {
+        const { fixture, harness } = await setupTestEnvironment({
+            testComponent: TestComponent,
+            harness: TrashIconHarness,
+        });
+
+        return {
+            testComponent: fixture!.componentInstance,
+            harness: harness!,
+        };
+    }
+
+    it('host has aria-hidden set to "true"', async () => {
+        const { harness } = await setupTest();
+        expect(await harness.isAriaHidden()).toBe(true);
+    });
+
+    it('no size class is applied by default', async () => {
+        const { harness } = await setupTest();
+
+        for (const size of Object.values(IconSizes)) {
+            expect(await harness.hasSize(size)).toBe(false);
+        }
+    });
+
+    it.each(Object.values(IconSizes))('size "%s" applies the correct class to the host', async (size) => {
+        const { harness, testComponent } = await setupTest();
+        testComponent.size.set(size);
+
+        expect(await harness.hasSize(size)).toBe(true);
+    });
+
+    it('SVG element is present in rendered output', async () => {
+        const { harness } = await setupTest();
+        expect(await harness.hasSvg()).toBe(true);
+    });
+});

--- a/packages/arcane-ui/icons/lib/trash/trash-icon.component.ts
+++ b/packages/arcane-ui/icons/lib/trash/trash-icon.component.ts
@@ -1,0 +1,26 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { IconDirective } from '../icon.directive';
+
+/**
+ * Trash icon for removal actions.
+ *
+ * The icon inherits its color from `currentColor` and is `aria-hidden` by default,
+ * so a visible or screen-reader-accessible label must be provided by the parent.
+ *
+ * @example
+ * ```html
+ * <!-- scales with surrounding text -->
+ * <dma-icon-trash />
+ *
+ * <!-- explicit size -->
+ * <dma-icon-trash size="lg" />
+ * ```
+ */
+@Component({
+    selector: 'dma-icon-trash',
+    templateUrl: `./trash-icon.component.html`,
+    styleUrl: './trash-icon.component.scss',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    hostDirectives: [{ directive: IconDirective, inputs: ['size'] }],
+})
+export class TrashIconComponent {}

--- a/packages/arcane-ui/icons/public-api.ts
+++ b/packages/arcane-ui/icons/public-api.ts
@@ -1,2 +1,3 @@
 export { IconDirective } from './lib/icon.directive';
 export { SpinnerIconComponent } from './lib/spinner/spinner-icon.component';
+export { TrashIconComponent } from './lib/trash/trash-icon.component';

--- a/packages/arcane-ui/icons/testing/lib/trash-icon.harness.ts
+++ b/packages/arcane-ui/icons/testing/lib/trash-icon.harness.ts
@@ -1,0 +1,5 @@
+import { BaseIconHarness } from './base-icon.harness';
+
+export class TrashIconHarness extends BaseIconHarness {
+    public static readonly hostSelector = 'dma-icon-trash';
+}

--- a/packages/arcane-ui/icons/testing/public-api.ts
+++ b/packages/arcane-ui/icons/testing/public-api.ts
@@ -1,2 +1,3 @@
 export { BaseIconHarness } from './lib/base-icon.harness';
 export { SpinnerIconHarness } from './lib/spinner-icon.harness';
+export { TrashIconHarness } from './lib/trash-icon.harness';


### PR DESCRIPTION
## Summary

### Context

Issue #269 requested a `TrashIconComponent` for the `arcane-ui` icons entry point, intended for use in removal actions across the application. No such icon existed in the library.

### Changes

Adds a `TrashIconComponent` to the `arcane-ui` icons entry point following the same pattern as `SpinnerIconComponent`. The component uses `hostDirectives` to wire up the shared `IconDirective` (which handles `aria-hidden` and size token classes) and the `_icon-base.scss` mixin for sizing and SVG fill. The Font Awesome trash can SVG provided by the author is embedded as a static template. A `TrashIconHarness` extending `BaseIconHarness` is included for testing, along with a spec covering aria-hidden, default size, all explicit sizes, and SVG presence. Both the main and testing public APIs are updated to export the new component and harness.

## Breaking Changes

## Test Plan

- [x] Run `pnpm moon run arcane-ui:test-ci` and confirm all tests pass.
- [x] Import `TrashIconComponent` into a host component, render `<dma-icon-trash />`, and confirm the trash icon appears and scales with surrounding text.
- [x] Render `<dma-icon-trash size="md" />` and confirm the explicit size class is applied.

Closes: #269