### PR TITLE
Add methods and docs to button and icon harnesses

### DIFF
--- a/packages/arcane-ui/components/testing/lib/button-link.harness.ts
+++ b/packages/arcane-ui/components/testing/lib/button-link.harness.ts
@@ -1,37 +1,92 @@
 import { ComponentHarness } from '@angular/cdk/testing';
 import {
     buttonAppearanceAttr,
+    ButtonAppearances,
     buttonIntentAttr,
+    ButtonIntents,
     buttonSizeAttr,
+    DEFAULT_BUTTON_APPEARANCE,
+    DEFAULT_BUTTON_INTENT,
     type ButtonAppearance,
     type ButtonIntent,
     type ButtonSize,
 } from '@dnd-mapp/arcane-ui/common';
 
+/** Test harness for {@link ButtonLinkComponent} — targets `a[dma-button-link]` elements. */
 export class ButtonLinkHarness extends ComponentHarness {
+    /** CDK host selector targeting native `<a>` elements with the `dma-button-link` attribute. */
     public static readonly hostSelector = 'a[dma-button-link]';
 
+    /** Returns `true` if the host has the CSS class corresponding to the given appearance. */
     public async hasAppearance(appearance: ButtonAppearance): Promise<boolean> {
         return (await this.host()).hasClass(buttonAppearanceAttr(appearance));
     }
 
+    /** Returns `true` if the host has the CSS class corresponding to the given intent. */
     public async hasIntent(intent: ButtonIntent): Promise<boolean> {
         return (await this.host()).hasClass(buttonIntentAttr(intent));
     }
 
+    /** Returns `true` if the host has the CSS class corresponding to the given size. */
     public async hasSize(size: ButtonSize): Promise<boolean> {
         return (await this.host()).hasClass(buttonSizeAttr(size));
     }
 
+    /** Returns `true` if the link is in icon-only mode (the `icon-only` CSS class is present). */
     public async isIconOnly(): Promise<boolean> {
         return (await this.host()).hasClass('icon-only');
     }
 
+    /** Returns `true` if the link stretches to fill its container (the `full-width` CSS class is present). */
     public async isFullWidth(): Promise<boolean> {
         return (await this.host()).hasClass('full-width');
     }
 
+    /**
+     * Returns `true` if the link is disabled.
+     *
+     * Because `<a>` has no native `disabled` property, disabled state is expressed via
+     * `aria-disabled="true"` on the host element.
+     */
     public async isDisabled(): Promise<boolean> {
         return (await this.host()).getAttribute('aria-disabled').then((v) => v === 'true');
+    }
+
+    /** Clicks the link. */
+    public async click(): Promise<void> {
+        return (await this.host()).click();
+    }
+
+    /** Returns the trimmed text content of the link. */
+    public async getText(): Promise<string> {
+        return (await this.host()).text();
+    }
+
+    /**
+     * Returns the active {@link ButtonAppearance} by inspecting the host's CSS classes.
+     * Falls back to {@link DEFAULT_BUTTON_APPEARANCE} when no recognised class is found.
+     */
+    public async getAppearance(): Promise<ButtonAppearance> {
+        const host = await this.host();
+        for (const appearance of Object.values(ButtonAppearances)) {
+            if (await host.hasClass(buttonAppearanceAttr(appearance))) {
+                return appearance;
+            }
+        }
+        return DEFAULT_BUTTON_APPEARANCE;
+    }
+
+    /**
+     * Returns the active {@link ButtonIntent} by inspecting the host's CSS classes.
+     * Falls back to {@link DEFAULT_BUTTON_INTENT} when no recognised class is found.
+     */
+    public async getIntent(): Promise<ButtonIntent> {
+        const host = await this.host();
+        for (const intent of Object.values(ButtonIntents)) {
+            if (await host.hasClass(buttonIntentAttr(intent))) {
+                return intent;
+            }
+        }
+        return DEFAULT_BUTTON_INTENT;
     }
 }

--- a/packages/arcane-ui/components/testing/lib/button.harness.ts
+++ b/packages/arcane-ui/components/testing/lib/button.harness.ts
@@ -1,41 +1,92 @@
 import { ComponentHarness } from '@angular/cdk/testing';
 import {
     buttonAppearanceAttr,
+    ButtonAppearances,
     buttonIntentAttr,
+    ButtonIntents,
     buttonSizeAttr,
+    DEFAULT_BUTTON_APPEARANCE,
+    DEFAULT_BUTTON_INTENT,
     type ButtonAppearance,
     type ButtonIntent,
     type ButtonSize,
 } from '@dnd-mapp/arcane-ui/common';
 
+/** Test harness for {@link ButtonComponent} — targets `button[dma-button]` elements. */
 export class ButtonHarness extends ComponentHarness {
+    /** CDK host selector targeting native `<button>` elements with the `dma-button` attribute. */
     public static readonly hostSelector = 'button[dma-button]';
 
+    /** Returns `true` if the host has the CSS class corresponding to the given appearance. */
     public async hasAppearance(appearance: ButtonAppearance): Promise<boolean> {
         return (await this.host()).hasClass(buttonAppearanceAttr(appearance));
     }
 
+    /** Returns `true` if the host has the CSS class corresponding to the given intent. */
     public async hasIntent(intent: ButtonIntent): Promise<boolean> {
         return (await this.host()).hasClass(buttonIntentAttr(intent));
     }
 
+    /** Returns `true` if the host has the CSS class corresponding to the given size. */
     public async hasSize(size: ButtonSize): Promise<boolean> {
         return (await this.host()).hasClass(buttonSizeAttr(size));
     }
 
+    /** Returns `true` if the button is in icon-only mode (the `icon-only` CSS class is present). */
     public async isIconOnly(): Promise<boolean> {
         return (await this.host()).hasClass('icon-only');
     }
 
+    /** Returns `true` if the button is in loading state (the `loading` CSS class is present). */
     public async isLoading(): Promise<boolean> {
         return (await this.host()).hasClass('loading');
     }
 
+    /** Returns `true` if the button stretches to fill its container (the `full-width` CSS class is present). */
     public async isFullWidth(): Promise<boolean> {
         return (await this.host()).hasClass('full-width');
     }
 
+    /** Returns `true` if the native `disabled` property is set on the host element. */
     public async isDisabled(): Promise<boolean> {
         return (await this.host()).getProperty<boolean>('disabled');
+    }
+
+    /** Clicks the button. */
+    public async click(): Promise<void> {
+        return (await this.host()).click();
+    }
+
+    /** Returns the trimmed text content of the button. */
+    public async getText(): Promise<string> {
+        return (await this.host()).text();
+    }
+
+    /**
+     * Returns the active {@link ButtonAppearance} by inspecting the host's CSS classes.
+     * Falls back to {@link DEFAULT_BUTTON_APPEARANCE} when no recognised class is found.
+     */
+    public async getAppearance(): Promise<ButtonAppearance> {
+        const host = await this.host();
+        for (const appearance of Object.values(ButtonAppearances)) {
+            if (await host.hasClass(buttonAppearanceAttr(appearance))) {
+                return appearance;
+            }
+        }
+        return DEFAULT_BUTTON_APPEARANCE;
+    }
+
+    /**
+     * Returns the active {@link ButtonIntent} by inspecting the host's CSS classes.
+     * Falls back to {@link DEFAULT_BUTTON_INTENT} when no recognised class is found.
+     */
+    public async getIntent(): Promise<ButtonIntent> {
+        const host = await this.host();
+        for (const intent of Object.values(ButtonIntents)) {
+            if (await host.hasClass(buttonIntentAttr(intent))) {
+                return intent;
+            }
+        }
+        return DEFAULT_BUTTON_INTENT;
     }
 }

--- a/packages/arcane-ui/icons/testing/lib/arrow-up-right-from-square-icon.harness.ts
+++ b/packages/arcane-ui/icons/testing/lib/arrow-up-right-from-square-icon.harness.ts
@@ -1,5 +1,7 @@
 import { BaseIconHarness } from './base-icon.harness';
 
+/** Test harness for the arrow-up-right-from-square icon component. */
 export class ArrowUpRightFromSquareIconHarness extends BaseIconHarness {
+    /** CDK host selector targeting `<dma-icon-arrow-up-right-from-square>` elements. */
     public static readonly hostSelector = 'dma-icon-arrow-up-right-from-square';
 }

--- a/packages/arcane-ui/icons/testing/lib/base-icon.harness.ts
+++ b/packages/arcane-ui/icons/testing/lib/base-icon.harness.ts
@@ -1,17 +1,22 @@
 import { ComponentHarness } from '@angular/cdk/testing';
 import { type IconSize } from '@dnd-mapp/arcane-ui/common';
 
+/** Abstract base harness shared by all icon component harnesses. */
 export abstract class BaseIconHarness extends ComponentHarness {
+    /** Locator for all `<svg>` elements within the icon host. */
     protected readonly svgLocator = this.locatorForAll('svg');
 
+    /** Returns `true` if `aria-hidden="true"` is set on the host element. */
     public async isAriaHidden(): Promise<boolean> {
         return (await (await this.host()).getAttribute('aria-hidden')) === 'true';
     }
 
+    /** Returns `true` if the host has the CSS class corresponding to the given size. */
     public async hasSize(size: IconSize): Promise<boolean> {
         return (await this.host()).hasClass(size);
     }
 
+    /** Returns `true` if at least one `<svg>` element is rendered inside the host. */
     public async hasSvg(): Promise<boolean> {
         return (await this.svgLocator()).length > 0;
     }

--- a/packages/arcane-ui/icons/testing/lib/pen-icon.harness.ts
+++ b/packages/arcane-ui/icons/testing/lib/pen-icon.harness.ts
@@ -1,5 +1,7 @@
 import { BaseIconHarness } from './base-icon.harness';
 
+/** Test harness for the pen icon component. */
 export class PenIconHarness extends BaseIconHarness {
+    /** CDK host selector targeting `<dma-icon-pen>` elements. */
     public static readonly hostSelector = 'dma-icon-pen';
 }

--- a/packages/arcane-ui/icons/testing/lib/plus-icon.harness.ts
+++ b/packages/arcane-ui/icons/testing/lib/plus-icon.harness.ts
@@ -1,5 +1,7 @@
 import { BaseIconHarness } from './base-icon.harness';
 
+/** Test harness for the plus icon component. */
 export class PlusIconHarness extends BaseIconHarness {
+    /** CDK host selector targeting `<dma-icon-plus>` elements. */
     public static readonly hostSelector = 'dma-icon-plus';
 }

--- a/packages/arcane-ui/icons/testing/lib/spinner-icon.harness.ts
+++ b/packages/arcane-ui/icons/testing/lib/spinner-icon.harness.ts
@@ -1,5 +1,7 @@
 import { BaseIconHarness } from './base-icon.harness';
 
+/** Test harness for the spinner icon component. */
 export class SpinnerIconHarness extends BaseIconHarness {
+    /** CDK host selector targeting `<dma-icon-spinner>` elements. */
     public static readonly hostSelector = 'dma-icon-spinner';
 }

--- a/packages/arcane-ui/icons/testing/lib/trash-icon.harness.ts
+++ b/packages/arcane-ui/icons/testing/lib/trash-icon.harness.ts
@@ -1,5 +1,7 @@
 import { BaseIconHarness } from './base-icon.harness';
 
+/** Test harness for the trash icon component. */
 export class TrashIconHarness extends BaseIconHarness {
+    /** CDK host selector targeting `<dma-icon-trash>` elements. */
     public static readonly hostSelector = 'dma-icon-trash';
 }


### PR DESCRIPTION
## Summary

### Context

`ButtonHarness` and `ButtonLinkHarness` (in `@dnd-mapp/arcane-ui/components/testing`) were missing common interaction and inspection methods that consumers need when writing tests for features built on top of button components. The icon harnesses also lacked inline documentation, making them harder to discover.

### Changes

- Added `click()`, `getText()`, `getAppearance()`, and `getIntent()` to both `ButtonHarness` and `ButtonLinkHarness`
- Added JSDoc comments to all public members of `ButtonHarness`, `ButtonLinkHarness`, `BaseIconHarness`, and the five concrete icon harnesses

## Test Plan

- [x] Run `pnpm moon run arcane-ui:test-ci` and confirm all tests pass
- [x] Verify `getAppearance()` and `getIntent()` return the expected value for each variant
- [x] Verify `click()` triggers the host element's click handler in a test

Closes: #245