### PR TITLE
feat(arcane-ui): Add base input foundation

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-pnpm exec lint-staged
+pnpm lint-staged

--- a/README.md
+++ b/README.md
@@ -51,10 +51,42 @@ Monorepo for the D&D Mapp platform — libraries and applications powering chara
     pnpm install
     ```
 
-4. Set up the Husky init script so that git hooks can find the correct Node and pnpm versions:
+4. Set up the Husky init script so that git hooks can find the correct Node and
+   pnpm versions. On Windows, Husky runs in Git Bash, so use POSIX-formatted
+   mise shim paths instead of evaluating the native Windows
+   `mise activate bash` output:
 
     ```sh
-    mkdir -p ~/.config/husky && echo 'eval "$(mise activate bash)"' >> ~/.config/husky/init.sh
+    mkdir -p ~/.config/husky
+    ```
+
+    Add the following to `~/.config/husky/init.sh`:
+
+    ```sh
+    case "$(uname -s)" in
+        MINGW*|MSYS*|CYGWIN*)
+            mise_data_dir="${MISE_DATA_DIR:-"$HOME/AppData/Local/mise"}"
+            case "$mise_data_dir" in
+                [A-Za-z]:\\*) mise_data_dir="$(cygpath -u "$mise_data_dir")" ;;
+            esac
+
+            if mise_command="$(command -v mise 2>/dev/null)"; then
+                mise_bin_dir="$(dirname "$mise_command")"
+            else
+                scoop_dir="${SCOOP:-"$HOME/scoop"}"
+                case "$scoop_dir" in
+                    [A-Za-z]:\\*) scoop_dir="$(cygpath -u "$scoop_dir")" ;;
+                esac
+                mise_bin_dir="$scoop_dir/apps/mise/current/bin"
+            fi
+
+            export PATH="$mise_data_dir/shims:$mise_bin_dir:$PATH"
+            unset mise_data_dir mise_command mise_bin_dir scoop_dir
+            ;;
+        *)
+            eval "$(mise activate bash)"
+            ;;
+    esac
     ```
 
 5. **(Windows only)** Enable git long-path support. Storybook's content-hashed cache filenames exceed Windows' 260-character `MAX_PATH` limit and cause git to fail without this setting:

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "prepare": "husky",
     "certs:generate": "mkcert -cert-file certs/local.pem -key-file certs/local-key.pem localhost.www.dndmapp.dev localhost.auth.dndmapp.dev localhost 127.0.0.1 ::1",
     "moon": "moon",
+    "lint-staged": "lint-staged",
     "commitlint": "commitlint",
     "playwright-install": "playwright install chromium --with-deps",
     "lint-md": "markdownlint-cli2 --config .markdownlint-cli2.json",

--- a/packages/arcane-ui/components/lib/input/base-input.component.spec.ts
+++ b/packages/arcane-ui/components/lib/input/base-input.component.spec.ts
@@ -1,0 +1,243 @@
+import { ComponentHarness } from '@angular/cdk/testing';
+import { Component, signal } from '@angular/core';
+import { FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
+import { setupTestEnvironment } from '@dnd-mapp/arcane-ui/testing';
+import { BaseInputComponent, type InputStatus } from './base-input.component';
+
+describe('BaseInputComponent', () => {
+    @Component({
+        selector: 'dma-test-input',
+        template: `
+            <label [for]="inputId()">{{ label() }}</label>
+            <input
+                [id]="inputId()"
+                [value]="value() ?? ''"
+                [disabled]="effectiveDisabled()"
+                [attr.data-status]="effectiveStatus()"
+                (input)="updateValue($any($event.target).value)"
+                (blur)="markAsTouched()"
+            />
+            <span class="helper-text" [id]="helperTextId()"></span>
+            <span class="error-message" [id]="errorMessageId()"></span>
+        `,
+    })
+    class TestInputComponent extends BaseInputComponent<string> {}
+
+    @Component({
+        selector: 'dma-test-standalone-host',
+        imports: [TestInputComponent],
+        template: `<dma-test-input inputId="name" label="Name" [disabled]="disabled()" />`,
+    })
+    class TestStandaloneHostComponent {
+        public readonly disabled = signal(false);
+    }
+
+    class TestInputHarness extends ComponentHarness {
+        public static readonly hostSelector = 'dma-test-input';
+
+        private readonly input = this.locatorFor('input');
+        private readonly label = this.locatorFor('label');
+        private readonly helperText = this.locatorFor('.helper-text');
+        private readonly errorMessage = this.locatorFor('.error-message');
+
+        public async getValue(): Promise<string> {
+            return (await this.input()).getProperty<string>('value');
+        }
+
+        public async setValue(value: string): Promise<void> {
+            const input = await this.input();
+            await input.setInputValue(value);
+            await input.dispatchEvent('input');
+        }
+
+        public async blur(): Promise<void> {
+            await (await this.input()).blur();
+        }
+
+        public async isDisabled(): Promise<boolean> {
+            return (await this.input()).getProperty<boolean>('disabled');
+        }
+
+        public async getStatus(): Promise<InputStatus> {
+            return (await (await this.input()).getAttribute('data-status')) as InputStatus;
+        }
+
+        public async getInputId(): Promise<string | null> {
+            return (await this.input()).getAttribute('id');
+        }
+
+        public async getLabel(): Promise<string> {
+            return (await this.label()).text();
+        }
+
+        public async getLabelFor(): Promise<string | null> {
+            return (await this.label()).getAttribute('for');
+        }
+
+        public async getHelperTextId(): Promise<string | null> {
+            return (await this.helperText()).getAttribute('id');
+        }
+
+        public async getErrorMessageId(): Promise<string | null> {
+            return (await this.errorMessage()).getAttribute('id');
+        }
+    }
+
+    @Component({
+        selector: 'dma-test-host',
+        imports: [ReactiveFormsModule, TestInputComponent],
+        template: `
+            <dma-test-input
+                inputId="character-name"
+                label="Character name"
+                [formControl]="control"
+                [status]="status()"
+            />
+        `,
+    })
+    class TestHostComponent {
+        public readonly control = new FormControl('', {
+            nonNullable: true,
+            validators: Validators.required,
+        });
+        public readonly status = signal<InputStatus | undefined>(undefined);
+    }
+
+    async function setupStandaloneInput() {
+        const { fixture, harness } = await setupTestEnvironment({
+            testComponent: TestStandaloneHostComponent,
+            harness: TestInputHarness,
+        });
+
+        return {
+            harness: harness!,
+            host: fixture!.componentInstance,
+        };
+    }
+
+    async function setupFormInput() {
+        const { fixture, harness } = await setupTestEnvironment({
+            testComponent: TestHostComponent,
+            harness: TestInputHarness,
+        });
+
+        return {
+            harness: harness!,
+            host: fixture!.componentInstance,
+        };
+    }
+
+    it('writes model values from Angular forms to the input', async () => {
+        const { harness, host } = await setupFormInput();
+
+        host.control.setValue('Gandalf');
+
+        expect(await harness.getValue()).toBe('Gandalf');
+    });
+
+    it('propagates user-entered values to Angular forms', async () => {
+        const { harness, host } = await setupFormInput();
+
+        await harness.setValue('Shadowfax');
+
+        expect(await harness.getValue()).toBe('Shadowfax');
+        expect(host.control.value).toBe('Shadowfax');
+    });
+
+    it('marks the Angular form control as touched on blur', async () => {
+        const { harness, host } = await setupFormInput();
+
+        await harness.blur();
+
+        expect(host.control.touched).toBe(true);
+    });
+
+    it('receives disabled state from Angular forms', async () => {
+        const { harness, host } = await setupFormInput();
+
+        expect(await harness.isDisabled()).toBe(false);
+
+        host.control.disable();
+        expect(await harness.isDisabled()).toBe(true);
+
+        host.control.enable();
+        expect(await harness.isDisabled()).toBe(false);
+    });
+
+    it('supports an explicit disabled input without Angular forms', async () => {
+        const { harness, host } = await setupStandaloneInput();
+
+        host.disabled.set(true);
+        expect(await harness.isDisabled()).toBe(true);
+    });
+
+    it('exposes required inputs and derives stable description IDs', async () => {
+        const { harness } = await setupStandaloneInput();
+
+        expect(await harness.getInputId()).toBe('name');
+        expect(await harness.getLabel()).toBe('Name');
+        expect(await harness.getLabelFor()).toBe('name');
+        expect(await harness.getHelperTextId()).toBe('name-helper');
+        expect(await harness.getErrorMessageId()).toBe('name-error');
+    });
+
+    it('defaults to a neutral status without an NgControl', async () => {
+        const { harness } = await setupStandaloneInput();
+
+        expect(await harness.getStatus()).toBe('default');
+    });
+
+    it('stays neutral while its invalid control is untouched and pristine', async () => {
+        const { harness } = await setupFormInput();
+
+        expect(await harness.getStatus()).toBe('default');
+    });
+
+    it('derives error from an invalid touched control', async () => {
+        const { harness, host } = await setupFormInput();
+
+        host.control.markAsTouched();
+
+        expect(await harness.getStatus()).toBe('error');
+    });
+
+    it('derives error from an invalid dirty control', async () => {
+        const { harness, host } = await setupFormInput();
+
+        host.control.markAsDirty();
+
+        expect(await harness.getStatus()).toBe('error');
+    });
+
+    it('derives success from a valid interacted control', async () => {
+        const { harness, host } = await setupFormInput();
+
+        host.control.setValue('Aragorn');
+        host.control.markAsTouched();
+
+        expect(await harness.getStatus()).toBe('success');
+    });
+
+    it('returns to a neutral status when the control is reset', async () => {
+        const { harness, host } = await setupFormInput();
+        host.control.setValue('Legolas');
+        host.control.markAsTouched();
+        expect(await harness.getStatus()).toBe('success');
+
+        host.control.reset();
+
+        expect(await harness.getStatus()).toBe('default');
+    });
+
+    it('uses an explicit status override, including default', async () => {
+        const { harness, host } = await setupFormInput();
+        host.control.markAsTouched();
+        expect(await harness.getStatus()).toBe('error');
+
+        host.status.set('success');
+        expect(await harness.getStatus()).toBe('success');
+
+        host.status.set('default');
+        expect(await harness.getStatus()).toBe('default');
+    });
+});

--- a/packages/arcane-ui/components/lib/input/base-input.component.spec.ts
+++ b/packages/arcane-ui/components/lib/input/base-input.component.spec.ts
@@ -171,6 +171,15 @@ describe('BaseInputComponent', () => {
         expect(await harness.isDisabled()).toBe(true);
     });
 
+    it('supports user interaction without Angular forms', async () => {
+        const { harness } = await setupStandaloneInput();
+
+        await harness.setValue('Frodo');
+        await harness.blur();
+
+        expect(await harness.getValue()).toBe('Frodo');
+    });
+
     it('exposes required inputs and derives stable description IDs', async () => {
         const { harness } = await setupStandaloneInput();
 
@@ -216,6 +225,15 @@ describe('BaseInputComponent', () => {
         host.control.markAsTouched();
 
         expect(await harness.getStatus()).toBe('success');
+    });
+
+    it('stays neutral while an interacted control is pending validation', async () => {
+        const { harness, host } = await setupFormInput();
+
+        host.control.markAsTouched();
+        host.control.markAsPending();
+
+        expect(await harness.getStatus()).toBe('default');
     });
 
     it('returns to a neutral status when the control is reset', async () => {

--- a/packages/arcane-ui/components/lib/input/base-input.component.ts
+++ b/packages/arcane-ui/components/lib/input/base-input.component.ts
@@ -1,0 +1,134 @@
+import { afterNextRender, computed, DestroyRef, Directive, inject, input, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { NgControl, type ControlValueAccessor } from '@angular/forms';
+
+/** Visual validation states shared by Arcane UI input components. */
+export type InputStatus = 'default' | 'error' | 'success';
+
+/**
+ * Shared value-accessor and validation-state foundation for Arcane UI inputs.
+ *
+ * Concrete input components are responsible for rendering the native control and
+ * forwarding user interactions through {@link updateValue} and {@link markAsTouched}.
+ */
+@Directive()
+export abstract class BaseInputComponent<TValue> implements ControlValueAccessor {
+    private readonly ngControl = inject(NgControl, { optional: true, self: true });
+    private readonly destroyRef = inject(DestroyRef);
+    private readonly formDisabled = signal(false);
+    private readonly controlStateRevision = signal(0);
+
+    /** ID applied to the native input and used to derive related ARIA IDs. */
+    public readonly inputId = input.required<string>();
+
+    /** Visible label associated with the native input. */
+    public readonly label = input.required<string>();
+
+    /** Whether the input is required. */
+    public readonly required = input(false);
+
+    /** Placeholder forwarded to the native input. */
+    public readonly placeholder = input<string>();
+
+    /** Autocomplete hint forwarded to the native input. */
+    public readonly autocomplete = input<string>();
+
+    /** Whether the input is read-only. */
+    public readonly readonly = input(false);
+
+    /** Whether the consumer has explicitly disabled the input. */
+    public readonly disabled = input(false);
+
+    /** Supporting text rendered alongside the input. */
+    public readonly helperText = input<string>();
+
+    /** Validation error text rendered alongside the input. */
+    public readonly errorMessage = input<string>();
+
+    /** Explicit status override. When omitted, status is derived from Angular forms. */
+    public readonly status = input<InputStatus>();
+
+    /** Stable ID for the helper-text element. */
+    public readonly helperTextId = computed(() => `${this.inputId()}-helper`);
+
+    /** Stable ID for the error-message element. */
+    public readonly errorMessageId = computed(() => `${this.inputId()}-error`);
+
+    /** Current value rendered by the concrete input component. */
+    protected readonly value = signal<TValue | null>(null);
+
+    /** Effective disabled state from either the input binding or Angular forms. */
+    protected readonly effectiveDisabled = computed(() => this.disabled() || this.formDisabled());
+
+    /** Explicit or form-derived validation status. */
+    protected readonly effectiveStatus = computed<InputStatus>(() => {
+        this.controlStateRevision();
+
+        const explicitStatus = this.status();
+
+        if (explicitStatus !== undefined) {
+            return explicitStatus;
+        }
+        const control = this.ngControl?.control;
+
+        if (!control || (!control.touched && !control.dirty)) {
+            return 'default';
+        }
+        if (control.invalid) {
+            return 'error';
+        }
+        if (control.valid) {
+            return 'success';
+        }
+        return 'default';
+    });
+
+    /** Callback registered by Angular forms for value changes. */
+    protected onChange: (value: TValue | null) => void = () => undefined;
+
+    /** Callback registered by Angular forms for touch events. */
+    protected onTouched: () => void = () => undefined;
+
+    public constructor() {
+        if (this.ngControl) {
+            this.ngControl.valueAccessor = this;
+        }
+
+        afterNextRender(() => {
+            this.ngControl?.control?.events.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
+                this.controlStateRevision.update((revision) => revision + 1);
+            });
+        });
+    }
+
+    /** Receives model values from Angular forms without notifying the model again. */
+    public writeValue(value: TValue | null): void {
+        this.value.set(value);
+    }
+
+    /** Registers the callback used to propagate user-entered values. */
+    public registerOnChange(fn: (value: TValue | null) => void): void {
+        this.onChange = fn;
+    }
+
+    /** Registers the callback used to mark the form control as touched. */
+    public registerOnTouched(fn: () => void): void {
+        this.onTouched = fn;
+    }
+
+    /** Receives disabled-state changes from Angular forms. */
+    public setDisabledState(isDisabled: boolean): void {
+        this.formDisabled.set(isDisabled);
+    }
+
+    /** Updates the rendered value and propagates a user-originated change. */
+    protected updateValue(value: TValue | null): void {
+        this.value.set(value);
+        this.onChange(value);
+    }
+
+    /** Marks the concrete input as touched. */
+    protected markAsTouched(): void {
+        this.onTouched();
+    }
+}

--- a/packages/arcane-ui/config/lib/config.service.spec.ts
+++ b/packages/arcane-ui/config/lib/config.service.spec.ts
@@ -2,7 +2,7 @@ import { provideHttpClient } from '@angular/common/http';
 import { TestBed } from '@angular/core/testing';
 import { CONFIG_URL } from '@dnd-mapp/arcane-ui/common';
 import { RequestService } from '@dnd-mapp/arcane-ui/http';
-import { setupTestEnvironment } from '@dnd-mapp/arcane-ui/testing';
+import { MSW_START_OPTIONS, setupTestEnvironment } from '@dnd-mapp/arcane-ui/testing';
 import { http, HttpResponse } from 'msw';
 import { setupWorker } from 'msw/browser';
 import { ConfigService } from './config.service';
@@ -16,7 +16,7 @@ describe('ConfigService', () => {
     const server = setupWorker();
 
     beforeAll(async () => {
-        await server.start({ onUnhandledRequest: 'warn', quiet: true });
+        await server.start(MSW_START_OPTIONS);
     });
 
     afterEach(() => {

--- a/packages/arcane-ui/http/lib/request.service.spec.ts
+++ b/packages/arcane-ui/http/lib/request.service.spec.ts
@@ -1,6 +1,6 @@
 import { provideHttpClient } from '@angular/common/http';
 import { TestBed } from '@angular/core/testing';
-import { setupTestEnvironment } from '@dnd-mapp/arcane-ui/testing';
+import { MSW_START_OPTIONS, setupTestEnvironment } from '@dnd-mapp/arcane-ui/testing';
 import { http, HttpResponse } from 'msw';
 import { setupWorker } from 'msw/browser';
 import { firstValueFrom } from 'rxjs';
@@ -20,7 +20,7 @@ describe('RequestService', () => {
     const baseUrl = 'https://api.test';
 
     beforeAll(async () => {
-        await server.start({ onUnhandledRequest: 'warn', quiet: true });
+        await server.start(MSW_START_OPTIONS);
     });
 
     afterEach(() => {

--- a/packages/arcane-ui/package.json
+++ b/packages/arcane-ui/package.json
@@ -29,6 +29,7 @@
     "@angular/cdk": "^21.2.0",
     "@angular/common": "^21.2.0",
     "@angular/core": "^21.2.0",
+    "@angular/forms": "^21.2.0",
     "@angular/platform-browser": "^21.2.0",
     "rxjs": "^7.8.0"
   },

--- a/packages/arcane-ui/testing/public-api.ts
+++ b/packages/arcane-ui/testing/public-api.ts
@@ -1,1 +1,2 @@
+export { MSW_START_OPTIONS } from './utils/msw-start-options';
 export { setupTestEnvironment } from './utils/setup-test-environment';

--- a/packages/arcane-ui/testing/utils/msw-start-options.spec.ts
+++ b/packages/arcane-ui/testing/utils/msw-start-options.spec.ts
@@ -1,0 +1,23 @@
+import { MSW_START_OPTIONS } from './msw-start-options';
+
+describe('MSW_START_OPTIONS', () => {
+    it('bypasses Vite source-map support requests', () => {
+        const warning = vi.fn();
+        const request = new Request(
+            'http://localhost:51204/@fs/D:/workspace/virtual:source-map-support?import&browser=123',
+        );
+
+        MSW_START_OPTIONS.onUnhandledRequest(request, { warning });
+
+        expect(warning).not.toHaveBeenCalled();
+    });
+
+    it('warns about other unhandled requests', () => {
+        const warning = vi.fn();
+        const request = new Request('https://api.test/unhandled');
+
+        MSW_START_OPTIONS.onUnhandledRequest(request, { warning });
+
+        expect(warning).toHaveBeenCalledOnce();
+    });
+});

--- a/packages/arcane-ui/testing/utils/msw-start-options.ts
+++ b/packages/arcane-ui/testing/utils/msw-start-options.ts
@@ -1,0 +1,16 @@
+interface UnhandledRequestPrint {
+    warning(): void;
+}
+
+/** Shared MSW browser-worker options for Arcane UI tests. */
+export const MSW_START_OPTIONS = {
+    quiet: true,
+    onUnhandledRequest(request: Request, print: UnhandledRequestPrint): void {
+        const pathname = new URL(request.url).pathname;
+
+        if (pathname.includes('virtual:source-map-support')) {
+            return;
+        }
+        print.warning();
+    },
+};

--- a/packages/arcane-ui/tsconfig.spec.json
+++ b/packages/arcane-ui/tsconfig.spec.json
@@ -3,7 +3,7 @@
     "files": ["vitest.config.mts"],
     "include": ["**/*.ts", "**/*.spec.ts", "**/*.stories.ts"],
     "compilerOptions": {
-        "outDir": "../../out-tsc/test",
+        "outDir": "out-tsc/test",
         "types": ["node", "vitest/globals"]
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,8 +116,8 @@ catalogs:
       specifier: ~5.9.3
       version: 5.9.3
     vite:
-      specifier: ~7.3.5
-      version: 7.3.5
+      specifier: ~8.0.16
+      version: 8.0.16
   eslint:
     eslint:
       specifier: ~10.5.0
@@ -386,6 +386,9 @@ importers:
       '@angular/core':
         specifier: ^21.2.0
         version: 21.2.17(@angular/compiler@21.2.17)(rxjs@7.8.2)
+      '@angular/forms':
+        specifier: ^21.2.0
+        version: 21.2.17(@angular/common@21.2.17(@angular/core@21.2.17(@angular/compiler@21.2.17)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.17(@angular/compiler@21.2.17)(rxjs@7.8.2))(@angular/platform-browser@21.2.17(@angular/animations@21.2.17(@angular/core@21.2.17(@angular/compiler@21.2.17)(rxjs@7.8.2)))(@angular/common@21.2.17(@angular/core@21.2.17(@angular/compiler@21.2.17)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.17(@angular/compiler@21.2.17)(rxjs@7.8.2)))(rxjs@7.8.2)
       '@angular/platform-browser':
         specifier: ^21.2.0
         version: 21.2.17(@angular/animations@21.2.17(@angular/core@21.2.17(@angular/compiler@21.2.17)(rxjs@7.8.2)))(@angular/common@21.2.17(@angular/core@21.2.17(@angular/compiler@21.2.17)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.17(@angular/compiler@21.2.17)(rxjs@7.8.2))
@@ -428,19 +431,19 @@ importers:
         version: link:../stylelint-config
       '@storybook/addon-docs':
         specifier: catalog:storybook
-        version: 10.4.5(@types/react@19.2.17)(esbuild@0.28.1)(rollup@4.62.0)(storybook@10.4.5(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(less@4.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.46.0)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))
+        version: 10.4.5(@types/react@19.2.17)(esbuild@0.28.1)(rollup@4.62.0)(storybook@10.4.5(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(less@4.4.2)(sass@1.101.0)(terser@5.46.0)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))
       '@storybook/angular':
         specifier: catalog:storybook
         version: 10.4.5(a6662fe8a7f98f614c4fa203c2747039)
       '@storybook/builder-vite':
         specifier: catalog:storybook
-        version: 10.4.5(esbuild@0.28.1)(rollup@4.62.0)(storybook@10.4.5(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(less@4.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.46.0)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))
+        version: 10.4.5(esbuild@0.28.1)(rollup@4.62.0)(storybook@10.4.5(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(less@4.4.2)(sass@1.101.0)(terser@5.46.0)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.4
       '@vitest/browser-playwright':
         specifier: catalog:vitest
-        version: 4.1.9(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(playwright@1.61.0)(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(less@4.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.46.0)(yaml@2.9.0))(vitest@4.1.9)
+        version: 4.1.9(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(playwright@1.61.0)(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(less@4.4.2)(sass@1.101.0)(terser@5.46.0)(yaml@2.9.0))(vitest@4.1.9)
       '@vitest/coverage-v8':
         specifier: catalog:vitest
         version: 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
@@ -491,10 +494,10 @@ importers:
         version: 8.61.0(eslint@10.5.0(jiti@2.7.0))(typescript@5.9.3)
       vite:
         specifier: 'catalog:'
-        version: 7.3.5(@types/node@24.12.4)(jiti@2.7.0)(less@4.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.46.0)(yaml@2.9.0)
+        version: 8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(less@4.4.2)(sass@1.101.0)(terser@5.46.0)(yaml@2.9.0)
       vitest:
         specifier: catalog:vitest
-        version: 4.1.9(@types/node@24.12.4)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(less@4.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.46.0)(yaml@2.9.0))
+        version: 4.1.9(@types/node@24.12.4)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(less@4.4.2)(sass@1.101.0)(terser@5.46.0)(yaml@2.9.0))
     publishDirectory: dist/arcane-ui
 
   packages/eslint-config:
@@ -7608,46 +7611,6 @@ packages:
       yaml:
         optional: true
 
-  vite@7.3.5:
-    resolution: {integrity: sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^20.19.0 || >=22.12.0
-      jiti: '>=1.21.0'
-      less: ^4.0.0
-      lightningcss: ^1.21.0
-      sass: ^1.70.0
-      sass-embedded: ^1.70.0
-      stylus: '>=0.54.8'
-      sugarss: ^5.0.0
-      terser: ^5.16.0
-      tsx: ^4.8.1
-      yaml: ^2.4.2
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      jiti:
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-      tsx:
-        optional: true
-      yaml:
-        optional: true
-
   vite@8.0.16:
     resolution: {integrity: sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -8335,7 +8298,7 @@ snapshots:
       lmdb: 3.5.1
       ng-packagr: 21.2.5(@angular/compiler-cli@21.2.17(@angular/compiler@21.2.17)(typescript@5.9.3))(tslib@2.8.1)(typescript@5.9.3)
       postcss: 8.5.12
-      vitest: 4.1.9(@types/node@24.12.4)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(less@4.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.46.0)(yaml@2.9.0))
+      vitest: 4.1.9(@types/node@24.12.4)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(less@4.4.2)(sass@1.101.0)(terser@5.46.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -8391,7 +8354,7 @@ snapshots:
       lmdb: 3.5.1
       ng-packagr: 21.2.5(@angular/compiler-cli@21.2.17(@angular/compiler@21.2.17)(typescript@5.9.3))(tslib@2.8.1)(typescript@5.9.3)
       postcss: 8.5.15
-      vitest: 4.1.9(@types/node@24.12.4)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(less@4.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.46.0)(yaml@2.9.0))
+      vitest: 4.1.9(@types/node@24.12.4)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(less@4.4.2)(sass@1.101.0)(terser@5.46.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -11129,10 +11092,10 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@storybook/addon-docs@10.4.5(@types/react@19.2.17)(esbuild@0.28.1)(rollup@4.62.0)(storybook@10.4.5(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(less@4.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.46.0)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))':
+  '@storybook/addon-docs@10.4.5(@types/react@19.2.17)(esbuild@0.28.1)(rollup@4.62.0)(storybook@10.4.5(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(less@4.4.2)(sass@1.101.0)(terser@5.46.0)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.17)(react@19.2.7)
-      '@storybook/csf-plugin': 10.4.5(esbuild@0.28.1)(rollup@4.62.0)(storybook@10.4.5(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(less@4.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.46.0)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))
+      '@storybook/csf-plugin': 10.4.5(esbuild@0.28.1)(rollup@4.62.0)(storybook@10.4.5(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(less@4.4.2)(sass@1.101.0)(terser@5.46.0)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))
       '@storybook/icons': 2.0.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@storybook/react-dom-shim': 10.4.5(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.5(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
       react: 19.2.7
@@ -11187,12 +11150,12 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/builder-vite@10.4.5(esbuild@0.28.1)(rollup@4.62.0)(storybook@10.4.5(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(less@4.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.46.0)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))':
+  '@storybook/builder-vite@10.4.5(esbuild@0.28.1)(rollup@4.62.0)(storybook@10.4.5(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(less@4.4.2)(sass@1.101.0)(terser@5.46.0)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))':
     dependencies:
-      '@storybook/csf-plugin': 10.4.5(esbuild@0.28.1)(rollup@4.62.0)(storybook@10.4.5(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(less@4.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.46.0)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))
+      '@storybook/csf-plugin': 10.4.5(esbuild@0.28.1)(rollup@4.62.0)(storybook@10.4.5(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(less@4.4.2)(sass@1.101.0)(terser@5.46.0)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))
       storybook: 10.4.5(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       ts-dedent: 2.3.0
-      vite: 7.3.5(@types/node@24.12.4)(jiti@2.7.0)(less@4.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.46.0)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(less@4.4.2)(sass@1.101.0)(terser@5.46.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - esbuild
       - rollup
@@ -11239,14 +11202,14 @@ snapshots:
       storybook: 10.4.5(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       ts-dedent: 2.3.0
 
-  '@storybook/csf-plugin@10.4.5(esbuild@0.28.1)(rollup@4.62.0)(storybook@10.4.5(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(less@4.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.46.0)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))':
+  '@storybook/csf-plugin@10.4.5(esbuild@0.28.1)(rollup@4.62.0)(storybook@10.4.5(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(less@4.4.2)(sass@1.101.0)(terser@5.46.0)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))':
     dependencies:
       storybook: 10.4.5(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.28.1
       rollup: 4.62.0
-      vite: 7.3.5(@types/node@24.12.4)(jiti@2.7.0)(less@4.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.46.0)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(less@4.4.2)(sass@1.101.0)(terser@5.46.0)(yaml@2.9.0)
       webpack: 5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)
 
   '@storybook/global@5.0.0': {}
@@ -11531,13 +11494,13 @@ snapshots:
     dependencies:
       vite: 7.3.2(@types/node@24.12.4)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.48.0)(yaml@2.9.0)
 
-  '@vitest/browser-playwright@4.1.9(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(playwright@1.61.0)(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(less@4.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.46.0)(yaml@2.9.0))(vitest@4.1.9)':
+  '@vitest/browser-playwright@4.1.9(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(playwright@1.61.0)(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(less@4.4.2)(sass@1.101.0)(terser@5.46.0)(yaml@2.9.0))(vitest@4.1.9)':
     dependencies:
-      '@vitest/browser': 4.1.9(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(less@4.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.46.0)(yaml@2.9.0))(vitest@4.1.9)
-      '@vitest/mocker': 4.1.9(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(less@4.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.46.0)(yaml@2.9.0))
+      '@vitest/browser': 4.1.9(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(less@4.4.2)(sass@1.101.0)(terser@5.46.0)(yaml@2.9.0))(vitest@4.1.9)
+      '@vitest/mocker': 4.1.9(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(less@4.4.2)(sass@1.101.0)(terser@5.46.0)(yaml@2.9.0))
       playwright: 1.61.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@types/node@24.12.4)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(less@4.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.46.0)(yaml@2.9.0))
+      vitest: 4.1.9(@types/node@24.12.4)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(less@4.4.2)(sass@1.101.0)(terser@5.46.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -11557,16 +11520,16 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.9(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(less@4.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.46.0)(yaml@2.9.0))(vitest@4.1.9)':
+  '@vitest/browser@4.1.9(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(less@4.4.2)(sass@1.101.0)(terser@5.46.0)(yaml@2.9.0))(vitest@4.1.9)':
     dependencies:
       '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.9(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(less@4.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.46.0)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.9(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(less@4.4.2)(sass@1.101.0)(terser@5.46.0)(yaml@2.9.0))
       '@vitest/utils': 4.1.9
       magic-string: 0.30.21
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@types/node@24.12.4)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(less@4.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.46.0)(yaml@2.9.0))
+      vitest: 4.1.9(@types/node@24.12.4)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(less@4.4.2)(sass@1.101.0)(terser@5.46.0)(yaml@2.9.0))
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
@@ -11624,14 +11587,14 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.9(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(less@4.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.46.0)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.9(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(less@4.4.2)(sass@1.101.0)(terser@5.46.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.14.6(@types/node@24.12.4)(typescript@5.9.3)
-      vite: 7.3.5(@types/node@24.12.4)(jiti@2.7.0)(less@4.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.46.0)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(less@4.4.2)(sass@1.101.0)(terser@5.46.0)(yaml@2.9.0)
 
   '@vitest/mocker@4.1.9(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.6)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0))':
     dependencies:
@@ -15624,7 +15587,7 @@ snapshots:
       picomatch: 4.0.4
       postcss: 8.5.15
       rollup: 4.62.0
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 24.12.4
       fsevents: 2.3.3
@@ -15642,7 +15605,7 @@ snapshots:
       picomatch: 4.0.4
       postcss: 8.5.15
       rollup: 4.62.0
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 24.12.4
       fsevents: 2.3.3
@@ -15653,20 +15616,19 @@ snapshots:
       terser: 5.48.0
       yaml: 2.9.0
 
-  vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(less@4.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.46.0)(yaml@2.9.0):
+  vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(less@4.4.2)(sass@1.101.0)(terser@5.46.0)(yaml@2.9.0):
     dependencies:
-      esbuild: 0.27.7
-      fdir: 6.5.0(picomatch@4.0.4)
+      lightningcss: 1.32.0
       picomatch: 4.0.4
       postcss: 8.5.15
-      rollup: 4.62.0
+      rolldown: 1.0.3
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 24.12.4
+      esbuild: 0.28.1
       fsevents: 2.3.3
       jiti: 2.7.0
       less: 4.4.2
-      lightningcss: 1.32.0
       sass: 1.101.0
       terser: 5.46.0
       yaml: 2.9.0
@@ -15688,10 +15650,10 @@ snapshots:
       terser: 5.48.0
       yaml: 2.9.0
 
-  vitest@4.1.9(@types/node@24.12.4)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(less@4.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.46.0)(yaml@2.9.0)):
+  vitest@4.1.9(@types/node@24.12.4)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(less@4.4.2)(sass@1.101.0)(terser@5.46.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.9
-      '@vitest/mocker': 4.1.9(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(less@4.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.46.0)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.9(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(less@4.4.2)(sass@1.101.0)(terser@5.46.0)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.9
       '@vitest/runner': 4.1.9
       '@vitest/snapshot': 4.1.9
@@ -15708,11 +15670,11 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 7.3.5(@types/node@24.12.4)(jiti@2.7.0)(less@4.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.46.0)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(less@4.4.2)(sass@1.101.0)(terser@5.46.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.12.4
-      '@vitest/browser-playwright': 4.1.9(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(playwright@1.61.0)(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(less@4.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.46.0)(yaml@2.9.0))(vitest@4.1.9)
+      '@vitest/browser-playwright': 4.1.9(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(playwright@1.61.0)(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(less@4.4.2)(sass@1.101.0)(terser@5.46.0)(yaml@2.9.0))(vitest@4.1.9)
       '@vitest/coverage-v8': 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
       '@vitest/ui': 4.1.9(vitest@4.1.9)
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -46,7 +46,7 @@ catalogs:
     semver: '~7.8.4'
     tslib: '~2.8.1'
     typescript: '~5.9.3'
-    vite: '~7.3.5'
+    vite: '~8.0.16'
   eslint:
     eslint: '~10.5.0'
     eslint-config-prettier: '~10.1.8'


### PR DESCRIPTION
## Summary

### Context

Arcane UI's planned input components need a shared Angular forms foundation that keeps ControlValueAccessor behavior, disabled state, validation feedback, and accessibility IDs consistent without exposing an unfinished public component API.

### Changes

Adds an internal generic `BaseInputComponent<TValue>` with signal inputs, Angular-managed ControlValueAccessor integration, effective disabled and validation status derivation, control-state event tracking, and stable helper and error IDs. Adds harness-driven coverage through a concrete test input, centralizes MSW worker options so Vite source-map helper requests are bypassed while unexpected application requests still warn, and updates Arcane UI's Angular Forms peer dependency and Vite 8 test setup.

## Test Plan

- [x] Run the Arcane UI unit test suite with the repository's installed moonrepo version.
- [x] Run Arcane UI TypeScript lint and the production library build.
- [x] Verify the focused base-input tests and MSW unhandled-request regression coverage.

Closes: #300